### PR TITLE
Properly clean up temporary files

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -152,7 +152,7 @@ jobs:
         docker compose --ansi never build
         docker compose --ansi never up -d --quiet-pull
         docker compose --ansi never logs -f &
-        docker compose exec api python3 -m unittest -k tests.integration
+        make test
     - name: Build and push
       uses: docker/build-push-action@v4
       if: github.ref == 'refs/heads/main' || github.event_name == 'release'

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ restart:
 
 test: start
 	@diff config/whisper.json config/whisper.json.testing
-	python3 -m unittest -k tests.integration
+	$(DOCKER_COMPOSE) exec api python3 -m unittest -k tests.integration
 
 coverage:
 	coverage run -m unittest -k tests.unit

--- a/app/api.py
+++ b/app/api.py
@@ -77,9 +77,10 @@ def queue_for_transcription(call_audio: UploadFile, call_json: UploadFile):
             break
         raw_audio.write(data)
 
-    audio_url = storage.upload_raw_audio(metadata, raw_audio.name)
-
-    os.unlink(raw_audio.name)
+    try:
+        audio_url = storage.upload_raw_audio(metadata, raw_audio.name)
+    finally:
+        os.unlink(raw_audio.name)
 
     task = transcribe_task.apply_async(
         queue="transcribe",
@@ -137,9 +138,10 @@ def create_call(
             break
         raw_audio.write(data)
 
-    audio_url = storage.upload_raw_audio(metadata, raw_audio.name)
-
-    os.unlink(raw_audio.name)
+    try:
+        audio_url = storage.upload_raw_audio(metadata, raw_audio.name)
+    finally:
+        os.unlink(raw_audio.name)
 
     call = schemas.CallCreate(raw_metadata=metadata, raw_audio_url=audio_url)
 

--- a/app/notification.py
+++ b/app/notification.py
@@ -123,7 +123,10 @@ def send_notifications(
                     alert_config, metadata, transcript_html, raw_audio_url, search_url
                 )
     finally:
-        os.unlink(ogg_file)
+        try:
+            os.unlink(ogg_file)
+        except:
+            pass
 
 
 def notify_channels(

--- a/bin/minio-entrypoint.sh
+++ b/bin/minio-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+minio server /data --console-address ":9001" &
+SERVER_PID=$!
+
+until /usr/bin/mc alias set minio http://127.0.0.1:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+do
+    sleep 1
+done
+/usr/bin/mc mb minio/${S3_BUCKET} ||:
+/usr/bin/mc anonymous set none minio/${S3_BUCKET}
+/usr/bin/mc anonymous set download minio/${S3_BUCKET}/*
+/usr/bin/mc cp /etc/hostname minio/${S3_BUCKET}/init-complete
+
+wait $SERVER_PID

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -10,28 +10,13 @@ services:
     environment:
       - MINIO_ROOT_USER=${AWS_ACCESS_KEY_ID}
       - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY}
-    command: server /data --console-address ":9001"
+      - S3_BUCKET
+    entrypoint: /bin/bash
+    command: /usr/bin/minio-entrypoint.sh
     volumes:
       - minio-storage:/data
-
-  minio-init:
-    image: quay.io/minio/mc
-    depends_on:
-      - minio
-    restart: on-failure:5
-    environment:
-      - S3_ENDPOINT=http://minio:9000
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - S3_BUCKET
-    entrypoint: >
-      /bin/sh -c "
-      /usr/bin/mc alias set local ${S3_ENDPOINT} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY};
-      /usr/bin/mc mb local/${S3_BUCKET};
-      /usr/bin/mc anonymous set none local/${S3_BUCKET};
-      /usr/bin/mc anonymous set download local/${S3_BUCKET}/*;
-      exit 0;
-      "
+      - ./bin/minio-entrypoint.sh:/usr/bin/minio-entrypoint.sh
+    restart: always
 
 volumes:
   minio-storage:

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -102,9 +102,7 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(
-            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
-        )
+        r = requests.get(result["hits"][0]["raw_audio_url"])
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 
@@ -133,9 +131,7 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(
-            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
-        )
+        r = requests.get(result["hits"][0]["raw_audio_url"])
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 
@@ -164,9 +160,7 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(
-            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
-        )
+        r = requests.get(result["hits"][0]["raw_audio_url"])
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import unittest
 from time import sleep
@@ -20,17 +21,21 @@ class TestEndToEnd(unittest.TestCase):
         index.delete()
         search.get_index(index_name)
 
-        show_success = False
         while True:
             try:
-                requests.get(url=str(os.getenv("API_BASE_URL")), timeout=5)
-                resp = requests.get(url=f"{os.getenv('S3_PUBLIC_URL')}/abc", timeout=5)
-                if show_success and resp.status_code == 404:
-                    print("Connected to API successfully.")
+                requests.get(
+                    url=f"{os.getenv('API_BASE_URL')}/config/notifications.json",
+                    headers={"Authorization": f"Bearer {os.getenv('API_KEY')}"},
+                    timeout=5,
+                ).raise_for_status()
+                requests.get(
+                    url=f"{os.getenv('S3_PUBLIC_URL')}/init-complete", timeout=5
+                ).raise_for_status()
+                logging.info("Connected to API successfully.")
                 break
-            except:
-                print("Waiting for API to come online...")
-                show_success = True
+            except Exception as e:
+                logging.error(e)
+                logging.info("Waiting for API to come online...")
                 sleep(1)
 
     def transcribe(
@@ -97,7 +102,9 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(result["hits"][0]["raw_audio_url"])
+        r = requests.get(
+            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
+        )
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 
@@ -126,7 +133,9 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(result["hits"][0]["raw_audio_url"])
+        r = requests.get(
+            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
+        )
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 
@@ -155,7 +164,9 @@ class TestEndToEnd(unittest.TestCase):
             isinstance(json.loads(result["hits"][0]["raw_transcript"]), list)
         )
 
-        r = requests.get(result["hits"][0]["raw_audio_url"])
+        r = requests.get(
+            result["hits"][0]["raw_audio_url"].replace("minio", "127.0.0.1")
+        )
         self.assertEqual(200, r.status_code)
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 


### PR DESCRIPTION
Some temporary files weren't getting cleaned up which led to running out of disk space, this ensures all temporary files get cleaned up no matter what.