### PR TITLE
Adding the option to batch calls to be transcribed

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,32 +1,118 @@
+# There are a variety of Docker Compose files that can be used to run the API and worker.
+# docker-compose.server.yml - API server, RabbitMQ, Meilisearch
+# docker-compose.minio.yml - MinIO (S3) server for local file storage
+# docker-compose.worker.yml - Transcription Worker
+# docker-compose.gpu.yml - Nvidia GPU support for the worker
+# docker-compose.openai.yml - OpenAI API support for the worker
+# docker-compose.autoscaler.yml - Autoscaler when using vast.ai to run workers
+
+# By default, this will run a self-contained setup, with the neccessary servers, worker, and GPU support
+# NOTE: On Windows, use ; to separate the files instead of :
+COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.minio.yml
+
+# Whisper model to use, choose from small.en, medium.en, large-v2, large-v3
+# By default, small.en will be used
+# For Deepgram, you can choose from the models on https://developers.deepgram.com/docs/model
+WHISPER_MODEL=small.en
+
+# Whisper implementation to use
+# By default, the original Whisper will be used
+# Available options:
+# - whisper (https://github.com/openai/whisper)
+# - faster-whisper (https://github.com/SYSTRAN/faster-whisper)
+# - whisper.cpp (https://github.com/ggerganov/whisper.cpp)
+# - whispers2t (https://github.com/shashikg/WhisperS2T)
+# - openai (OpenAI API)
+# - deepgram (Deepgram speech-to-text API, Nova 2 model)
+WHISPER_IMPLEMENTATION=openai
+
+# Which Dockerfile to use for building the worker
+# Available options:
+# Dockerfile.whisper (https://github.com/openai/whisper)
+# Dockerfile.fasterwhisper (https://github.com/SYSTRAN/faster-whisper)
+# Dockerfile.whispercpp (https://github.com/ggerganov/whisper.cpp)
+# Dockerfile.whispers2t (https://github.com/shashikg/WhisperS2T)
+WORKER_DOCKERFILE=Dockerfile.whisper
+
+# Desired CUDA version to use (as well as some special options).
+# Available options:
+# cu121 - CUDA 12.1 (required for faster-whisper and whispers2t)
+# cpu - regular Whisper on the CPU
 #
-# Celery settings
+# By default, cu121 will be used for the GPU, and cpu for the CPU
+DESIRED_CUDA=cu121
+
+# OpenAI API key, if using the paid Whisper API (and switch your WHISPER_IMPLEMENTATION to openai)
+# OPENAI_API_KEY=
+
+#
+# Queue settings
 #
 
-CELERY_LOGLEVEL=debug
-CELERY_BROKER_URL=amqp://localhost:5672
-CELERY_RESULT_BACKEND=rpc://localhost:5672
+# CELERY_LOGLEVEL=debug
+CELERY_BROKER_URL=amqp://rabbitmq:5672
+CELERY_RESULT_BACKEND=rpc://rabbitmq:5672
+# CELERY_CONCURRENCY=1
 
-FLOWER_BROKER_API=http://localhost:15672/api/
+FLOWER_BROKER_API=http://rabbitmq:15672/api/
+
+# To set auth on RabbitMQ (update URLs above if so, in the form user:pass@rabbitmq)
+# RABBITMQ_DEFAULT_USER=
+# RABBITMQ_DEFAULT_PASS=
+
+#
+# Database settings
+#
+
+# Uncomment the following to save calls to a database - will be required in future versions
+POSTGRES_HOST=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=trunk_transcribe
 
 #
 # API settings
 #
 
-API_BASE_URL=http://localhost:8000
+# This should be a publicly-accessible URL to the API server, from whever the worker is being run
+API_BASE_URL=http://api:8000
 API_KEY=testing
 
 #
 # Search settings
 #
 
+# Version of Meilisearch to use (e.g. v1.4.0)
+# MEILI_VERSION=
+
 MEILI_MASTER_KEY=testing
-MEILI_URL=http://localhost:7700
+MEILI_URL=http://meilisearch:7700
+# To use a different index name other than calls:
+# MEILI_INDEX=calls
+# For large systems, to make a new index for each month (e.g. calls_2024_01); MEILI_INDEX becomes the prefix
+# MEILI_INDEX_SPLIT_BY_MONTH=true
 
 #
 # Storage settings
 #
 
-S3_PUBLIC_URL=http://localhost:9000/trunk-transcribe
+# These settings are for an S3 bucket that will contain call audio, so it can be played back later as part of search.
+
+# S3_BUCKET=my-bucket
+# S3_PUBLIC_URL=https://my-bucket.s3.us-east-1.amazonaws.com
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+
+# If using a different location than us-east-1 or a provider with an S3-compatible API
+# S3_ENDPOINT=
+
+# To use MinIO and save files locally instead of signing up for S3, uncomment this section instead
+S3_BUCKET=trunk-transcribe
+# The S3 public URL should be the publicly-accessible IP or domain of the MinIO server, with the port and bucket name
+S3_PUBLIC_URL=http://minio:9000/trunk-transcribe
+AWS_ACCESS_KEY_ID=changeme
+AWS_SECRET_ACCESS_KEY=changeme
+S3_ENDPOINT=http://minio:9000
 
 #
 # Notification settings
@@ -35,3 +121,30 @@ S3_PUBLIC_URL=http://localhost:9000/trunk-transcribe
 # These values are in seconds
 DELAYED_CALL_THRESHOLD=120
 MAX_CALL_AGE=0
+
+#
+# Third party service settings
+#
+
+# TELEGRAM_BOT_TOKEN=
+
+# OPENAI_API_KEY=
+
+# GOOGLE_GEMINI_API_KEY=
+
+# GOOGLE_MAPS_API_KEY=
+# MAPBOX_API_KEY=
+# GEOCODIO_API_KEY=
+# ARCGIS_USERNAME=
+# ARCGIS_PASSWORD=
+
+GEOCODING_BOUNDS="41.6,-87.9|42,-87.5"
+GEOCODING_CITY=Chicago
+GEOCODING_STATE=IL
+GEOCODING_COUNTRY=US
+GEOCODING_ENABLED_SYSTEMS="chi_cpd,chi_cfd,chi_oemc,sc21102"
+
+# SENTRY_DSN=
+
+# BCFY_USER=
+# BCFY_PASS=

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,22 +140,10 @@ jobs:
       if: matrix.model == 'small.en' && matrix.desired_cuda == 'cpu' && matrix.variant == 'whisper' && github.event_name != 'release'
       run: |
         set -x
-        cp .env.example .env
-        sed -i 's/^COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.gpu.yml$/COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.minio.yml/g' .env
+        cp .env.testing .env
         sed -i 's/^WHISPER_MODEL=small.en$/WHISPER_MODEL=${{ matrix.model }}/g' .env
         sed -i 's/^DESIRED_CUDA=cu121$/DESIRED_CUDA=${{ matrix.desired_cuda }}/g' .env
         sed -i 's/^WORKER_DOCKERFILE=Dockerfile.whisper$/WORKER_DOCKERFILE=${{ matrix.dockerfile }}/g' .env
-        sed -i 's/^# POSTGRES/POSTGRES/g' .env
-        sed -i 's/^# S3_BUCKET=my-bucket$/S3_BUCKET=trunk-transcribe/g' .env
-        sed -i -E 's/^# S3_PUBLIC_URL=https(.*)$/S3_PUBLIC_URL=http:\/\/minio:9000\/trunk-transcribe/g' .env
-        sed -i 's/^# AWS_ACCESS_KEY_ID=$/AWS_ACCESS_KEY_ID=root/g' .env
-        sed -i 's/^# AWS_SECRET_ACCESS_KEY=$/AWS_SECRET_ACCESS_KEY=password/g' .env
-        sed -i 's/^# S3_ENDPOINT=$/S3_ENDPOINT=http:\/\/minio:9000/g' .env
-        sed -i 's/^# GEOCODING_BOUNDS="41.6,-87.9|42,-87.5"$/GEOCODING_BOUNDS="41,-88.5|42.5,-87.5"/g' .env
-        sed -i 's/^# GEOCODING_CITY=Chicago$/GEOCODING_CITY=Chicago/g' .env
-        sed -i 's/^# GEOCODING_STATE=IL$/GEOCODING_STATE=IL/g' .env
-        sed -i 's/^# GEOCODING_COUNTRY=US$/GEOCODING_COUNTRY=US/g' .env
-        sed -i 's/^# GEOCODING_ENABLED_SYSTEMS="system1,system2"$/GEOCODING_ENABLED_SYSTEMS="chi_cpd,chi_cfd,chi_oemc,sc21102"/g' .env
         echo "VERSION=${{ github.sha }}" >> .env
         cat .env
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To use the paid Whisper API by OpenAI instead of running the worker on a machine
 
 ```
 # To use the paid OpenAI Whisper API instead of running the model locally
-COMPOSE_FILE=docker-compose.yml:docker-compose.openai.yml
+COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.openai.yml
 
 # OpenAI API key, if using the paid Whisper API
 OPENAI_API_KEY=my-api-key
@@ -89,7 +89,7 @@ Run `bin/autoscale-vast.py` to start workers and autoscale them as needed. Run `
 To keep the autoscaler running, set the following in your `.env`:
 
 ```bash
-COMPOSE_FILE=COMPOSE_FILE=docker-compose.yml:docker-compose.noworker.yml:docker-compose.autoscaler.yml
+COMPOSE_FILE=COMPOSE_FILE=docker-compose.server.yml:docker-compose.autoscaler.yml
 # your API key from vast.ai, or omit to have it read from ~/.vast_api_key
 VAST_API_KEY=
 # Tune these settings as needed

--- a/app/analog.py
+++ b/app/analog.py
@@ -1,18 +1,18 @@
 from threading import Lock
 
 from .transcript import Transcript
-from .whisper import transcribe
+from .whisper import WhisperResult, transcribe
 
 
-def transcribe_call(model, model_lock: Lock, audio_file: str) -> Transcript:
-    response = transcribe(
-        model=model,
-        model_lock=model_lock,
-        audio_file=audio_file,
-        cleanup=True,
-        vad_filter=True,
-    )
+def build_transcribe_kwargs(audio_file: str) -> dict:
+    return {
+        "audio_file": audio_file,
+        "cleanup": True,
+        "vad_filter": True,
+    }
 
+
+def process_response(response: WhisperResult) -> Transcript:
     transcript = Transcript()
 
     for segment in response["segments"]:
@@ -22,3 +22,13 @@ def transcribe_call(model, model_lock: Lock, audio_file: str) -> Transcript:
             transcript.append(text)
 
     return transcript.validate()
+
+
+def transcribe_call(model, model_lock: Lock, audio_file: str) -> Transcript:
+    response = transcribe(
+        model=model,
+        model_lock=model_lock,
+        **build_transcribe_kwargs(audio_file),
+    )
+
+    return process_response(response)

--- a/app/whisper.py
+++ b/app/whisper.py
@@ -197,9 +197,11 @@ class WhisperS2T(BaseWhisper):
         method = self.model.transcribe
         if vad_filter:
             method = self.model.transcribe_with_vad
+        if not lang_codes:
+            lang_codes = ["en" for _ in audio_files]
         output = method(
             audio_files,
-            lang_codes=lang_codes if lang_codes else ["en" for _ in audio_files],
+            lang_codes=lang_codes,
             tasks=["transcribe" for _ in audio_files],
             initial_prompts=initial_prompts
             if initial_prompts

--- a/app/worker.py
+++ b/app/worker.py
@@ -146,19 +146,9 @@ def transcribe_and_index(
     id: str | None = None,
     index_name: str | None = None,
 ) -> str:
-    try:
-        if (
-            metadata["audio_type"] == "digital"
-            or metadata["audio_type"] == "digital tdma"
-        ):
-            transcript = transcribe_digital(model, model_lock, audio_file, metadata)
-        elif metadata["audio_type"] == "analog":
-            transcript = transcribe_analog(model, model_lock, audio_file)
-        else:
-            raise Reject(f"Audio type {metadata['audio_type']} not supported")
-    except WhisperException as e:
-        return repr(e)
-    logging.debug(transcript.json)
+    transcript = transcribe(model, model_lock, metadata, audio_file)
+    if not transcript:
+        return ""
 
     geo = lookup_geo(metadata, transcript)
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -242,7 +242,10 @@ def transcribe_from_db_task(
 
 
 @celery.task(
-    name="transcribe_db_batch", base=whisper.WhisperBatchTask, flush_every=50, flush_interval=10
+    name="transcribe_db_batch",
+    base=whisper.WhisperBatchTask,
+    flush_every=50,
+    flush_interval=10,
 )
 def transcribe_from_db_batch_task(requests):
     calls = []

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -24,6 +24,8 @@ elif [ "$1" = 'worker' ]; then
         fi
     fi
 
+    export LD_LIBRARY_PATH=`python3 -c 'import os; import nvidia.cublas.lib; import nvidia.cudnn.lib; print(os.path.dirname(nvidia.cublas.lib.__file__) + ":" + os.path.dirname(nvidia.cudnn.lib.__file__))'`
+
     exec celery --app=app.worker.celery worker \
         -P ${CELERY_POOL:-prefork} \
         -c ${CELERY_CONCURRENCY:-1} \

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -187,6 +187,9 @@ class TestEndToEnd(unittest.TestCase):
         self.assertEqual("audio/mpeg", r.headers.get("content-type"))
 
     def test_transcribes_in_batch(self):
+        if os.getenv("WHISPER_IMPLEMENTATION") != "whispers2t":
+            self.skipTest("WHISPER_IMPLEMENTATION must be whispers2t to test")
+
         result = self.transcribe(
             "tests/data/9051-1699224861_773043750.0-call_20452.wav",
             "tests/data/9051-1699224861_773043750.0-call_20452.json",

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -10,7 +10,6 @@ from meilisearch.errors import MeilisearchApiError
 
 from app import search
 
-load_dotenv(".env.testing")
 load_dotenv()
 
 

--- a/tests/integration/test_geocoding.py
+++ b/tests/integration/test_geocoding.py
@@ -11,7 +11,6 @@ from app import geocoding
 from app.metadata import Metadata
 from app.transcript import Transcript
 
-load_dotenv(".env.testing")
 load_dotenv()
 
 

--- a/tests/integration/test_notification.py
+++ b/tests/integration/test_notification.py
@@ -5,11 +5,9 @@ from time import sleep
 
 import requests
 from dotenv import load_dotenv
-from geopy.point import Point
 
 from app import notification
 
-load_dotenv(".env.testing")
 load_dotenv()
 
 


### PR DESCRIPTION
This adds support for batching transcription of calls when using `whispers2t` as the `WHISPER_IMPLEMENTATION` and with the Postgres database enabled. This also requires `?batch=true` to be passed in the API call from the trunk-recorder upload script.