### PR TITLE
Docs: add Sirens execution plan and planning docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ This directory stores product, UX, and implementation planning documents for the
 
 - `architecture.md`: Mermaid system diagram, backend reference table, and shared transcription runtime contract.
 - `crimeisdown-site-product-spec.md`: product spec for the public `crimeisdown.com` site and the premium `sirens.app` split, including sitemap, copy, and route-by-route wireframes.
+- `sirens-linear-execution-plan.md`: recommended execution order for the open Sirens Linear tranche in `trunk-transcribe`, including dependencies, phases, and deprioritized backlog items.

--- a/docs/crimeisdown-site-product-spec.md
+++ b/docs/crimeisdown-site-product-spec.md
@@ -1,0 +1,751 @@
+# CrimeIsDown Website Product Spec
+
+## Document Status
+
+- Status: Draft
+- Date: 2026-03-16
+- Scope: Public `crimeisdown.com` site and premium `sirens.app` product split
+- Exclusions: `Directive Changes` is removed entirely from the new site structure
+
+## Product Summary
+
+CrimeIsDown should stop behaving like a flat directory of unrelated tools and instead guide users through the primary job to be done:
+
+`I heard sirens. What is happening near me?`
+
+The updated product structure should separate the free public utility from the premium investigative workflow.
+
+- `crimeisdown.com` is the free public front door for Chicago scanner context.
+- `sirens.app` is the premium workflow for searchable transcripts, incident analysis, saved alerts, and AI assistance.
+
+This split keeps the public site focused and easier to understand while preserving room for a much more powerful premium experience.
+
+## Goals
+
+### Primary Goals
+
+1. Make location the default entry point for new visitors.
+2. Reduce top-level navigation complexity.
+3. Keep the public site free, useful, and easy to understand.
+4. Move advanced search and premium workflows into `sirens.app`.
+5. Increase clarity around what each property is for.
+
+### Secondary Goals
+
+1. Improve conversion from public-site visitors to premium Sirens users.
+2. Consolidate scanner reference tools into a single coherent section.
+3. Reduce homepage clutter and historical digressions above the fold.
+
+## Non-Goals
+
+1. Rebuilding the backend architecture in this phase.
+2. Specifying visual design in pixel-level detail.
+3. Preserving the old `Directive Changes` feature or route.
+4. Keeping every current page as a top-level navigation item.
+
+## Target Users
+
+### Public Site Users
+
+- Chicago residents who hear sirens and want quick context
+- Scanner hobbyists who need boundaries, channels, and definitions
+- Journalists who need fast area and radio context
+- Casual visitors who want to listen live
+
+### Premium Users
+
+- Journalists and newsroom staff
+- Power users and heavy scanner listeners
+- Researchers tracking patterns over time
+- Users who want saved searches, alerts, and transcript search
+
+## Core Product Positioning
+
+### crimeisdown.com
+
+Public utility for:
+
+- finding scanner context by address
+- listening live
+- understanding scanner terms and codes
+- learning how Chicago public safety radio is organized
+
+### sirens.app
+
+Premium workflow for:
+
+- transcript search
+- incident map
+- saved searches
+- notifications and newsletters
+- AI-assisted interpretation and follow-up questions
+
+## Site Principles
+
+1. Start with place, not tools.
+2. Keep free and premium boundaries obvious.
+3. Put user goals in navigation labels.
+4. Keep advanced controls off first-touch experiences.
+5. Group support tools together instead of scattering them across pages.
+
+## Information Architecture
+
+## crimeisdown.com Sitemap
+
+1. `/` Home
+2. `/area` Find My Area
+3. `/listen` Listen Live
+4. `/listen/archives` Audio Archives
+5. `/reference` Scanner Reference
+6. `/reference/radio-ids` Radio ID Lookup
+7. `/reference/ucr-codes` UCR Code Lookup
+8. `/reference/guide` Scanner Guide
+9. `/about` About CrimeIsDown
+10. `/support` Support
+
+## sirens.app Sitemap
+
+1. `/` Premium Home
+2. `/search` Transcript Search
+3. `/map` Incident Map
+4. `/alerts` Alerts and Newsletters
+5. `/assistant` Scanner AI Assistant
+6. `/account` Account
+
+## Primary Navigation
+
+### crimeisdown.com
+
+- Find My Area
+- Listen
+- Reference
+- Sirens
+- About
+
+### sirens.app
+
+- Search
+- Map
+- Alerts
+- Assistant
+- Account
+
+## Global Content Strategy
+
+### Content to Remove
+
+- `Directive Changes` route
+- `Directive Changes` navigation item
+- homepage references that treat all tools as equally important
+
+### Content to Move Below the Fold or Into About
+
+- mission/history narrative
+- long-form explanation of the CrimeIsDown name
+- donation explanations
+- partner/source acknowledgements
+
+### Content to Elevate
+
+- location search
+- live listening
+- reference tools
+- premium upgrade path
+
+## Functional Requirements
+
+## Shared Requirements
+
+1. Navigation must clearly distinguish free public tools from premium Sirens features.
+2. All pages should include a persistent CTA to `Find My Area`.
+3. All pages should include a persistent CTA to `Open Sirens` where premium features are mentioned.
+4. Mobile layouts should prioritize the primary task on first viewport load.
+
+## crimeisdown.com Requirements
+
+1. Users can search for an address or place and see Chicago-specific boundary/context data.
+2. Users can listen to live scanner audio with minimal friction.
+3. Users can browse or search reference material without authentication.
+4. Users can discover premium features without being forced into them on basic tasks.
+
+## sirens.app Requirements
+
+1. Users can search transcripts by location, time, channel, and agency.
+2. Users can view search results on a map.
+3. Users can save searches and configure alerts.
+4. Users can ask AI follow-up questions using scanner-specific context.
+
+## Conversion Requirements
+
+1. The public site should frame Sirens as the deeper layer, not as the default starting point.
+2. Premium promotion should appear:
+   - on the homepage
+   - after area lookups
+   - on the listen page near archives and transcripts
+   - on the reference page where deeper analysis is likely useful
+
+## Route-by-Route Wireframe Outline
+
+## crimeisdown.com
+
+### `/` Home
+
+#### Purpose
+
+Give first-time visitors an immediate answer path and explain the free/premium split.
+
+#### Primary User Questions
+
+- I heard sirens. Where do I start?
+- What can I do for free here?
+- When should I use Sirens?
+
+#### Wireframe Sections
+
+1. Header
+   - Logo
+   - Nav: Find My Area, Listen, Reference, Sirens, About
+   - Optional support link in utility area
+2. Hero
+   - Headline: `Heard sirens in Chicago? Start with your location.`
+   - Subhead
+   - Address search field
+   - Primary CTA: `Find My Area`
+   - Secondary CTA: `Listen Live`
+3. Quick Actions Row
+   - Find My Area card
+   - Listen Live card
+   - Reference Tools card
+   - Search Transcripts card with premium badge
+4. How It Works
+   - Step 1: Search your address
+   - Step 2: Listen or look things up
+   - Step 3: Go deeper in Sirens
+5. Premium Promo Band
+   - Short value statement
+   - CTA to Sirens
+6. Trust / Source Strip
+   - Brief note on public data and scanner resources
+7. Footer
+   - About
+   - Support
+   - Contact
+
+#### Key Content
+
+- Keep copy short and action-oriented.
+- Do not place historical essays above the main CTA.
+
+### `/area` Find My Area
+
+#### Purpose
+
+Make address-based context the main public experience.
+
+#### Primary User Questions
+
+- What area am I in?
+- Which police district and beat cover this address?
+- Which channels should I listen to?
+
+#### Wireframe Sections
+
+1. Page Header
+   - Headline: `Find the scanner context for any Chicago address`
+   - Supporting line
+2. Search Module
+   - Address/place input
+   - CTA: `Search`
+   - Optional current-location button later
+3. Results Summary Card
+   - Neighborhood
+   - Community area
+   - Ward
+   - Police district
+   - Beat
+4. Recommended Channels Card
+   - Primary channels
+   - Secondary channels
+   - CTA: `Listen Live`
+5. Map Module
+   - Boundary layers
+   - Address pin
+   - Layer toggles
+6. Nearby Activity Module
+   - Demo nearby incidents or explanatory placeholder
+   - CTA: `Search Nearby Activity in Sirens`
+7. Next Steps Row
+   - Listen Live
+   - Open Reference
+   - Open Sirens
+
+#### Notes
+
+- This is the single most important page after the homepage.
+- It should be optimized for mobile first.
+
+### `/listen` Listen Live
+
+#### Purpose
+
+Give users an obvious place to hear current radio traffic without burying them in archive and pricing detail.
+
+#### Primary User Questions
+
+- How do I listen right now?
+- What is the main feed?
+- Where are the advanced audio options?
+
+#### Wireframe Sections
+
+1. Page Header
+   - Headline: `Listen to Chicago scanner audio`
+   - Supporting text
+2. Main Live Player
+   - Primary stream/player
+   - Short description of coverage
+3. Main Feed Module
+   - YouTube feed embed
+   - CTA: `Watch on YouTube`
+4. Recommended Sources Module
+   - OpenMHz links
+   - Broadcastify links
+   - Other specialty sources
+5. Audio Tools Module
+   - CTA card to `Audio Archives`
+   - CTA card to `Find My Area`
+   - CTA card to `Reference`
+6. Premium Promo Module
+   - `Need searchable history? Use Sirens transcript search.`
+
+#### Notes
+
+- Archive downloads and pricing should not dominate this page.
+- This page is for live listening first.
+
+### `/listen/archives` Audio Archives
+
+#### Purpose
+
+Separate archive lookup from live listening so both experiences are easier to scan.
+
+#### Primary User Questions
+
+- Can I search older recordings?
+- What is free vs paid?
+- How do I export or download audio?
+
+#### Wireframe Sections
+
+1. Page Header
+   - Headline: `Search scanner archives`
+   - Supporting text
+2. Archive Search Module
+   - Date/time input
+   - Channel/system selectors
+   - Search CTA
+3. Export / Download Module
+   - Clip export tools
+   - Download limits summary
+4. Access / Membership Module
+   - Clear free vs paid comparison
+   - CTA to Patreon or Sirens depending product choice
+5. Alternate Paths Row
+   - Listen Live
+   - Find My Area
+   - Search Transcripts in Sirens
+
+#### Notes
+
+- This is a utility page, not a top-level nav item.
+
+### `/reference` Scanner Reference
+
+#### Purpose
+
+Create one home for all interpretation tools.
+
+#### Primary User Questions
+
+- What does that code mean?
+- Who is unit 1234?
+- Where do I learn scanner terminology?
+
+#### Wireframe Sections
+
+1. Page Header
+   - Headline: `Scanner reference tools`
+   - Supporting text
+2. Tool Cards
+   - Radio ID Lookup
+   - UCR Code Lookup
+   - Scanner Guide
+3. Quick Search Strip
+   - Inline radio ID search
+   - Inline UCR search
+4. Learn the Basics Section
+   - Intro paragraph
+   - CTA to Scanner Guide
+5. Premium Assistant Promo
+   - `Need help interpreting a call? Ask the Sirens assistant.`
+
+#### Notes
+
+- Reference should be a coherent destination, not a scattered collection.
+
+### `/reference/radio-ids` Radio ID Lookup
+
+#### Purpose
+
+Provide a dedicated deep link for radio identifier lookup.
+
+#### Wireframe Sections
+
+1. Header
+2. Search input
+3. Result table
+4. Related links
+   - Scanner Guide
+   - UCR Codes
+   - Sirens Assistant
+
+### `/reference/ucr-codes` UCR Code Lookup
+
+#### Purpose
+
+Provide a dedicated deep link for UCR code lookup.
+
+#### Wireframe Sections
+
+1. Header
+2. Search input
+3. Result table
+4. Related links
+   - Radio IDs
+   - Scanner Guide
+   - Sirens Assistant
+
+### `/reference/guide` Scanner Guide
+
+#### Purpose
+
+Provide readable orientation for scanner terminology and Chicago-specific context.
+
+#### Wireframe Sections
+
+1. Header
+2. Guide overview
+3. Embedded guide content or migrated native content
+4. Related tools sidebar or cards
+   - Radio IDs
+   - UCR Codes
+   - Sirens Assistant
+
+#### Notes
+
+- Long term, move away from a Google Docs embed to native site content.
+
+### `/about` About CrimeIsDown
+
+#### Purpose
+
+Hold the history, mission, and source material that should not crowd the homepage.
+
+#### Wireframe Sections
+
+1. Header
+2. What this site does
+3. What stays free
+4. What moved to Sirens
+5. Sources and acknowledgements
+6. Contact
+
+### `/support` Support
+
+#### Purpose
+
+Keep funding asks off the homepage while still making them easy to find.
+
+#### Wireframe Sections
+
+1. Header
+2. Why support matters
+3. Patreon CTA
+4. PayPal CTA
+5. Optional infrastructure/mission summary
+
+## sirens.app
+
+### `/` Premium Home
+
+#### Purpose
+
+Serve as the premium landing page with a search-first workflow.
+
+#### Wireframe Sections
+
+1. Header
+2. Hero with location input
+3. Search nearby CTA
+4. Feature cards
+   - Transcript Search
+   - Incident Map
+   - Alerts
+   - Assistant
+5. Pricing/access summary
+
+### `/search` Transcript Search
+
+#### Purpose
+
+Search transcripts with a simpler entry point than the current advanced-first UI.
+
+#### Wireframe Sections
+
+1. Header
+2. Simple search mode
+   - location
+   - time
+   - agency
+3. Results list
+4. Advanced filters drawer
+5. Saved search CTA
+6. Ask Assistant CTA
+
+### `/map` Incident Map
+
+#### Purpose
+
+Show results spatially for premium users.
+
+#### Wireframe Sections
+
+1. Header
+2. Search summary
+3. Map
+4. Result drawer/list
+5. Related actions
+   - Save search
+   - Open assistant
+
+### `/alerts` Alerts and Newsletters
+
+#### Purpose
+
+Turn useful searches into subscriptions.
+
+#### Wireframe Sections
+
+1. Header
+2. Saved searches list
+3. New alert form
+4. Delivery settings
+5. Newsletter presets
+
+### `/assistant` Scanner AI Assistant
+
+#### Purpose
+
+Help users interpret terminology, summarize incidents, and ask follow-up questions.
+
+#### Wireframe Sections
+
+1. Header
+2. Prompt input
+3. Suggested prompts
+4. Conversation area
+5. Linked context/results rail
+
+### `/account` Account
+
+#### Purpose
+
+Provide account, plan, and preferences management.
+
+#### Wireframe Sections
+
+1. Header
+2. Membership/access summary
+3. Saved search count
+4. Notification settings
+5. Linked public-site tools
+
+## Detailed Page Copy
+
+## crimeisdown.com Copy
+
+### Home
+
+#### Hero
+
+- Headline: `Heard sirens in Chicago? Start with your location.`
+- Subhead: `Find the police district, beat, neighborhood, and scanner channels for any Chicago address. Then listen live or jump into deeper search tools.`
+- Primary CTA: `Find My Area`
+- Secondary CTA: `Listen Live`
+
+#### Quick Actions
+
+- Find My Area: `Enter an address to see the district, beat, community area, and the scanner channels most likely carrying traffic nearby.`
+- Listen Live: `Tune into live Chicago scanner audio, watch the general feed, and follow active radio traffic.`
+- Use Reference Tools: `Look up radio IDs, UCR codes, and scanner terminology when you hear something you do not recognize.`
+- Search Transcripts: `Need searchable call history and AI-assisted analysis? Use the premium Sirens platform.`
+
+#### How It Works
+
+- Step 1: `Search your address`
+- Step 1 Copy: `Get the local map context and the channels that matter.`
+- Step 2: `Listen or look things up`
+- Step 2 Copy: `Use live audio and scanner reference tools to understand what you are hearing.`
+- Step 3: `Go deeper if needed`
+- Step 3 Copy: `Use Sirens for transcript search, incident mapping, and alerts.`
+
+#### Premium Promo
+
+- Heading: `Need faster answers?`
+- Copy: `Sirens adds searchable transcripts, incident mapping, and saved alerts for journalists, researchers, and power users.`
+- CTA: `Open Sirens`
+
+### Find My Area
+
+- Headline: `Find the scanner context for any Chicago address`
+- Subhead: `See where an address sits in Chicago and which public safety channels are most relevant nearby.`
+- Input Placeholder: `Enter an address or place name`
+
+#### Results Labels
+
+- `Location Summary`
+- `Recommended Channels`
+- `Map Context`
+- `Nearby Activity`
+
+#### Supporting Copy
+
+- `This address is in [Neighborhood], Community Area [X], Ward [X], Police District [X], and Beat [X].`
+- `Start with these channels to hear traffic most likely related to this area.`
+- `View nearby boundaries and switch between district, beat, ward, and neighborhood layers.`
+- `Need more than map context? Search nearby activity in Sirens.`
+
+### Listen
+
+- Headline: `Listen to Chicago scanner audio`
+- Subhead: `Follow live public safety radio traffic, watch the main stream, or jump to archives and external sources.`
+
+#### Section Copy
+
+- `Start with the live scanner player for active Chicago-area radio traffic.`
+- `Watch the general #ChicagoScanner feed on YouTube for a broader citywide mix.`
+- `Need older audio? Search archive recordings by time and channel.`
+- `Use OpenMHz, Broadcastify, and specialty feeds when you want more coverage.`
+- `Need searchable history? Use Sirens transcript search.`
+
+### Audio Archives
+
+- Headline: `Search scanner archives`
+- Subhead: `Look up past recordings by date, time, and channel.`
+- Membership Copy: `Free access covers basic archive lookup. Expanded download and export limits are available through paid access.`
+
+### Reference
+
+- Headline: `Scanner reference tools`
+- Subhead: `Decode what you are hearing on Chicago public safety radio.`
+
+#### Card Copy
+
+- Radio IDs: `Look up unit and radio identifiers to understand who is talking.`
+- UCR Codes: `Translate incident reporting codes into plain language.`
+- Scanner Guide: `Learn scanner terms, Chicago-specific shorthand, and common dispatch patterns.`
+
+### About
+
+- Headline: `About CrimeIsDown`
+- Subhead: `CrimeIsDown helps Chicago scanner listeners understand where things are happening and what they are hearing.`
+
+#### Section Copy
+
+- `CrimeIsDown is built for residents, journalists, hobbyists, and anyone trying to make sense of Chicago scanner traffic quickly.`
+- `The public site focuses on location context, live listening, and reference tools.`
+- `Advanced transcript search, AI workflows, and alerts live in Sirens.`
+- `Mapping and reference data come from public datasets and scanner community resources.`
+
+### Support
+
+- Headline: `Support CrimeIsDown`
+- Copy: `Support keeps the public tools online and helps fund the infrastructure behind Chicago scanner coverage.`
+- CTA 1: `Support on Patreon`
+- CTA 2: `Donate with PayPal`
+
+## sirens.app Copy
+
+### Premium Home
+
+- Headline: `I heard sirens near...`
+- Subhead: `Search scanner transcripts, map incidents, and get faster answers from live Chicago radio traffic.`
+- Input Placeholder: `Enter an address, neighborhood, or landmark`
+- Primary CTA: `Search Nearby Activity`
+
+#### Feature Copy
+
+- Transcript Search: `Search recent radio traffic by location, time, agency, and channel.`
+- Incident Map: `See calls and related activity on a map instead of piecing it together manually.`
+- AI Assistant: `Ask follow-up questions about scanner terminology, calls, and patterns in the results.`
+- Alerts: `Save searches and get updates for the places and topics you care about.`
+
+## User Flows
+
+### Flow 1: Heard Sirens, Wants Quick Context
+
+1. User lands on `crimeisdown.com/`
+2. User enters address
+3. User reaches `/area`
+4. User checks district/beat/channel suggestions
+5. User clicks `Listen Live` or `Open Sirens`
+
+### Flow 2: Curious Scanner Listener
+
+1. User lands on `/listen`
+2. User starts live audio
+3. User hears unfamiliar term
+4. User opens `/reference`
+5. User looks up code or terminology
+
+### Flow 3: Journalist Needs Searchable Context
+
+1. User lands on `crimeisdown.com/`
+2. User sees premium prompt
+3. User opens `sirens.app/search`
+4. User filters by location and time
+5. User saves search or creates alert
+
+## Implementation Guidance
+
+### Public Site Priorities
+
+1. Rework homepage around address-first hero.
+2. Build `/area` as the flagship experience.
+3. Split live listening and archives into separate routes.
+4. Consolidate all lookup tools under `/reference`.
+5. Remove `Directive Changes` completely from routes, nav, and content.
+
+### Premium Priorities
+
+1. Replace advanced-first transcript search entry with a simpler starter mode.
+2. Keep advanced filters available, but secondary.
+3. Make saved alerts a first-class premium feature.
+
+## Success Metrics
+
+1. Increased clickthrough from homepage to `/area`
+2. Reduced bounce rate from homepage
+3. Increased clicks from public site to Sirens
+4. Increased completion of key flows:
+   - address search
+   - live listen start
+   - reference lookup
+   - premium search start
+
+## Open Questions
+
+1. Will archive access remain on `crimeisdown.com`, or eventually move into Sirens?
+2. Will premium access continue to be Patreon-authenticated, or migrate to a first-party account model?
+3. Should the public site expose a lightweight nearby-activity preview, or reserve all such results for Sirens?
+4. Should the scanner guide remain an embed in the short term, or be migrated immediately into native content?

--- a/docs/sirens-linear-execution-plan.md
+++ b/docs/sirens-linear-execution-plan.md
@@ -1,0 +1,360 @@
+# Sirens Linear Execution Plan
+
+Last updated: 2026-04-18
+
+## Scope
+
+This document captures the recommended execution order for the open Linear work in the `CrimeIsDown` team's `Sirens` project that applies to `trunk-transcribe`.
+
+The intent is to sequence the current Sirens integration tranche so architecture decisions land before interface work, and interface work lands before product-specific integrations.
+
+## Current repo context
+
+The current tranche is concentrated in the shared frontend:
+
+- `frontend/src/components/Search.tsx`
+- `frontend/src/components/TranscriptMap.tsx`
+- `frontend/src/components/SavedTranscriptSearches.tsx`
+- `frontend/src/lib/transcriptSavedSearches.ts`
+
+These files currently carry the main assumptions that need to be pushed behind reusable interfaces:
+
+- env-backed search credentials
+- browser-local saved searches
+- no authenticated viewer/capabilities bootstrap
+- no notification abstraction
+
+## Planning principles
+
+This ordering is based on four rules:
+
+1. Decide topology before building too much against an accidental app boundary.
+2. Introduce shared abstractions before adding Sirens-only adapters.
+3. Land lower-risk adapter work before higher-complexity user-state and alerts work.
+4. Keep Chicago-specific cleanup from blocking core commercial integration work.
+
+## Recommended execution order
+
+### 0. Triage the still-open search parent
+
+#### `CRI-42` Port over transcript search
+
+Status:
+- `In Progress`
+
+Why first:
+- Its child parity tasks appear to have already been completed.
+- This looks like an issue hygiene problem more than a large remaining implementation.
+- It should be closed, split, or refreshed before more Sirens platform work starts so the project state is accurate.
+
+Expected output:
+- confirm whether `CRI-42` is actually done
+- if not done, create follow-up tickets for concrete missing gaps
+- close or re-scope the parent issue
+
+### 1. Make the topology decision
+
+#### `CRI-69` Decide and document frontend app topology for `crimeisdown.com` and `sirens.app`
+
+Status:
+- `Backlog`
+
+Why this comes first:
+- The rest of the Sirens tranche assumes some frontend ownership model.
+- Without this decision, it is easy to overbuild inside `trunk-transcribe` or to introduce abstractions that fit the wrong deployment model.
+
+Decision to produce:
+- whether Sirens remains a mode within the existing frontend
+- whether Sirens moves to a separate private frontend
+- or whether the team uses a hybrid approach where shared packages stay here and product composition moves elsewhere later
+
+Expected output:
+- architecture decision record in `docs/`
+- explicit statement of what remains shared/open
+- explicit statement of what is private/product-specific
+
+Exit criteria:
+- follow-up tickets can reference a stable topology assumption
+
+### 2. Establish provider boundaries in the shared frontend
+
+#### `CRI-63` Introduce frontend providers for auth, entitlements, saved searches, notifications, and search credentials
+
+Status:
+- `Backlog`
+
+Why this is foundational:
+- This is the abstraction layer that all later Sirens integrations should plug into.
+- It prevents one-off direct integrations in `Search.tsx`, `TranscriptMap.tsx`, and saved-search UI code.
+
+Target interfaces:
+- `AuthProvider`
+- `ViewerProvider`
+- `EntitlementsService`
+- `SavedSearchStore`
+- `NotificationStore`
+- `SearchCredentialProvider`
+
+Default implementations to preserve current behavior:
+- anonymous/no-op auth
+- open/shared entitlements
+- `localStorage` saved searches
+- env-backed search credentials
+- no-op notifications
+
+Expected output:
+- shared components depend on interfaces rather than direct storage or env assumptions
+- current OSS behavior stays intact
+- Sirens adapters can be added without rewriting search and map components
+
+Primary code areas:
+- `frontend/src/components/Search.tsx`
+- `frontend/src/components/TranscriptMap.tsx`
+- `frontend/src/components/SavedTranscriptSearches.tsx`
+- `frontend/src/lib/transcriptSavedSearches.ts`
+
+### 3. Add viewer and capability bootstrap
+
+#### `CRI-65` Add a generic viewer and capabilities bootstrap contract for Sirens
+
+Status:
+- `Backlog`
+
+Why this comes immediately after `CRI-63`:
+- It gives the new provider model an actual authenticated contract to carry.
+- It is the cleanest way to gate premium behavior without leaking Patreon-specific logic into the shared frontend.
+
+Target contract shape:
+- `canSearchTranscripts`
+- `canCreateAlerts`
+- `canUseAssistant`
+- `archiveDepthDays`
+- `canExportAudio`
+
+Expected output:
+- frontend feature gating becomes capability-based
+- backend tier logic stays private to the backend
+- later Sirens adapters have a stable account-aware bootstrap model
+
+Can overlap with `CRI-63`:
+- yes, but final API shape should be finalized only after the provider model is clear
+
+### 4. Prove the adapter pattern with saved searches
+
+#### `CRI-64` Replace browser-only saved searches with a pluggable store and Sirens backend adapter
+
+Status:
+- `Backlog`
+
+Why this comes before search credentials and notifications:
+- It is the cleanest first adapter on top of the provider model.
+- It exercises authenticated user state without immediately taking on the complexity of alerts.
+- It reduces uncertainty in the frontend normalization layer.
+
+Expected output:
+- shared frontend uses `SavedSearchStore`
+- `localStorage` remains the default OSS/shared adapter
+- Sirens can use backend CRUD without a separate UI path
+
+Primary code areas:
+- `frontend/src/components/SavedTranscriptSearches.tsx`
+- `frontend/src/lib/transcriptSavedSearches.ts`
+- any provider wiring added in `CRI-63`
+
+Notes:
+- This should align with `CRI-65` where authenticated vs anonymous behavior matters.
+- It does not need to wait on notifications work.
+
+### 5. Replace browser search credentials with scoped backend-issued credentials
+
+#### `CRI-66` Use private backend-issued scoped search credentials in Sirens search and map flows
+
+Status:
+- `Backlog`
+
+Why this follows `CRI-63` and `CRI-65`:
+- It needs the `SearchCredentialProvider` abstraction from `CRI-63`.
+- It should use the viewer/capabilities contract from `CRI-65` to handle access failures and premium gating correctly.
+
+Why it is high priority:
+- This removes the need to ship privileged env-configured search credentials for premium flows.
+- It directly improves separation between open/shared mode and authenticated Sirens mode.
+
+Expected output:
+- `Search.tsx` and `TranscriptMap.tsx` request credentials through a provider
+- Sirens uses temporary scoped keys from the private backend
+- open/shared mode retains env-backed fallback behavior
+
+Primary code areas:
+- `frontend/src/components/Search.tsx`
+- `frontend/src/components/TranscriptMap.tsx`
+
+### 6. Integrate notifications and transcript subscriptions
+
+#### `CRI-67` Integrate notification channels and transcript subscriptions into the Sirens frontend
+
+Status:
+- `Backlog`
+
+Why this follows the prior work:
+- It depends on the provider boundary from `CRI-63`.
+- It should consume capability/bootstrap information from `CRI-65`.
+- It will likely benefit from patterns already established in `CRI-64`, since both are frontend-to-backend user-state integrations.
+
+Why this is later than saved searches:
+- Notifications have more product and UX ambiguity.
+- The issue explicitly includes alert creation from search state, map state, or both.
+- It will touch more flows and should build on already-proven adapter patterns.
+
+Expected output:
+- CRUD for notification channels through the private backend
+- CRUD for transcript subscriptions through the private backend
+- alert creation from normalized search/map state
+- feature naming aligned around `Alerts` in `sirens.app`
+
+Primary code areas:
+- provider layer introduced in `CRI-63`
+- shared search and map state flow
+- any alert creation UI introduced in the frontend
+
+### 7. Clean up Chicago-specific product behavior in parallel
+
+#### `CRI-68` Separate Chicago-specific product behavior from shared transcript-search core
+
+Status:
+- `Backlog`
+
+Why this is parallel work rather than a blocker:
+- It is important boundary cleanup, but the ticket itself says it should not block the provider-backed commercial integrations.
+- Its best shape depends somewhat on the topology decision in `CRI-69`.
+
+Recommended timing:
+- start after `CRI-69`
+- schedule as a parallel cleanup lane while `CRI-64` through `CRI-67` proceed
+
+Expected output:
+- inventory of Chicago-specific assumptions
+- configuration-driven or app-composed replacements for those assumptions
+- shared search and map components become city-agnostic by default
+
+Likely targets:
+- presets
+- copy
+- default market assumptions
+- any public-site-only behavior currently embedded in shared components
+
+## Dependency graph summary
+
+Required ordering:
+
+- `CRI-69` before major implementation in the current Sirens tranche
+- `CRI-63` before `CRI-64`
+- `CRI-63` before `CRI-66`
+- `CRI-63` before `CRI-67`
+- `CRI-65` before `CRI-66`
+- `CRI-65` before `CRI-67`
+
+Recommended but not strictly blocking:
+
+- `CRI-65` should be shaped alongside the provider model from `CRI-63`
+- `CRI-64` should land before `CRI-67` to establish the frontend pattern for backend-backed user state
+- `CRI-68` should be informed by `CRI-69`
+
+## Suggested implementation phases
+
+### Phase 1: Decision and issue hygiene
+
+Tickets:
+- `CRI-42`
+- `CRI-69`
+
+Goal:
+- make the project state accurate
+- remove ambiguity about frontend ownership and repo boundaries
+
+### Phase 2: Shared interfaces
+
+Tickets:
+- `CRI-63`
+- `CRI-65`
+
+Goal:
+- create stable frontend seams for authenticated Sirens behavior
+
+### Phase 3: First product integrations
+
+Tickets:
+- `CRI-64`
+- `CRI-66`
+
+Goal:
+- prove the adapter model with saved searches
+- move premium search access onto scoped backend credentials
+
+### Phase 4: Alerts and stateful premium workflows
+
+Tickets:
+- `CRI-67`
+
+Goal:
+- connect search and map state to backend-backed alerts and subscriptions
+
+### Phase 5: Shared-core cleanup
+
+Tickets:
+- `CRI-68`
+
+Goal:
+- make the shared frontend city-agnostic and product-agnostic by composition
+
+## Deprioritized backlog for this tranche
+
+These open `Sirens` tickets are not on the immediate dependency path and should not interrupt the current integration tranche unless priorities change:
+
+### `CRI-24` New OpenAI Models - Enhancement Request
+
+Why later:
+- useful and user-facing, but orthogonal to the current Sirens frontend boundary work
+
+When to pull forward:
+- if OpenAI model compatibility is currently blocking deployments or user adoption
+
+### `CRI-17` Improve geocoding accuracy
+
+Why later:
+- important bug, but not part of the current architecture and provider tranche
+
+When to pull forward:
+- if map accuracy is currently causing visible product errors
+
+### `CRI-50` Send update to patrons
+
+Why later:
+- communication task, not a technical blocker
+
+When to do it:
+- after at least one or two visible Sirens integration items have landed
+
+### `CRI-51` Train a transcription AI model
+
+Why later:
+- research-heavy and not dependent on the current frontend integration work
+
+### `CRI-47` CrimeIsDown app - take a picture of police, find out what is going on
+
+Why later:
+- large product exploration item with no current dependency on the tranche above
+
+### `CRI-48` AI generated newsletter on police/fire incidents
+
+Why later:
+- product expansion idea that should wait until the shared/core and Sirens boundaries are cleaner
+
+## Recommended next ticket to execute
+
+If implementation starts immediately, the next ticket should be:
+
+1. `CRI-69` if the topology decision is still unresolved
+2. `CRI-63` immediately after that decision is documented
+
+If the topology decision is already effectively known but undocumented, write it down first and then begin `CRI-63` in the same work window.

--- a/plans/2026-03-22-worker-backend-architecture-plan.md
+++ b/plans/2026-03-22-worker-backend-architecture-plan.md
@@ -1,0 +1,374 @@
+# Worker Backend Architecture Plan
+
+Status: proposed
+Date: 2026-03-22
+
+## Goal
+
+Allow an arbitrary set of computers to join the transcription pool by starting a backend-specific worker stack. Each machine should immediately help with the shared load for the backend it supports.
+
+This plan does not change code yet. It defines the target architecture and the implementation checklist.
+
+## Core Model
+
+- Route transcription jobs by backend queue, not by one global GPU queue.
+- Each machine runs one backend-specific worker stack.
+- A worker stack includes:
+  - one Celery worker consuming one backend queue
+  - any local inference service needed for that backend
+- Vast autoscaling launches more workers of the same backend type by watching that backend queue.
+
+## Queue Names
+
+- `transcribe_whisper`
+- `transcribe_qwen`
+- `transcribe_voxtral`
+- `post_transcribe`
+
+## Backend Model
+
+Supported backend values:
+
+- `whisper`
+- `qwen`
+- `voxtral`
+
+Default backend:
+
+- `whisper`
+
+## Worker Stack Compose Files
+
+Add these compose files:
+
+- `docker-compose.worker-whisper.yml`
+- `docker-compose.worker-qwen.yml`
+- `docker-compose.worker-voxtral.yml`
+
+Each compose file should fully define the services needed on that machine.
+
+### `docker-compose.worker-whisper.yml`
+
+Services:
+
+- `worker-whisper`
+- `asr-whisper` if using a local Whisper API container
+
+Queue:
+
+- `transcribe_whisper`
+
+Use cases:
+
+- CPU Linux
+- Apple Silicon
+- NVIDIA
+
+Notes:
+
+- The exact runtime can vary by image or env vars.
+- The operational model stays the same: start this stack and the machine joins the `transcribe_whisper` queue.
+
+### `docker-compose.worker-qwen.yml`
+
+Services:
+
+- `worker-qwen`
+- `asr-qwen`
+
+Queue:
+
+- `transcribe_qwen`
+
+Use cases:
+
+- NVIDIA-first
+
+Notes:
+
+- The worker should be thin and call a sibling Qwen inference service over HTTP.
+
+### `docker-compose.worker-voxtral.yml`
+
+Services:
+
+- `worker-voxtral`
+- optionally `asr-voxtral`
+
+Queue:
+
+- `transcribe_voxtral`
+
+Use cases:
+
+- local Voxtral serving if practical
+- external Voxtral API if not
+
+Notes:
+
+- This stack should support either local inference or API-backed inference without changing queue routing.
+
+## Generic Worker Environment Variables
+
+Add and standardize these env vars:
+
+- `DEFAULT_TRANSCRIPTION_BACKEND=whisper`
+- `TRANSCRIPTION_BACKEND=whisper|qwen|voxtral`
+- `CELERY_QUEUES=transcribe_whisper|transcribe_qwen|transcribe_voxtral`
+- `ASR_API_URL=http://asr-<backend>:8000/v1`
+- `ASR_MODEL=<model-name>`
+- `ASR_PROVIDER=<provider-name>`
+
+Keep existing Whisper-specific env vars temporarily for backward compatibility:
+
+- `WHISPER_IMPLEMENTATION`
+- `WHISPER_MODEL`
+- `ASR_API_URL` for existing `whisper-asr-api` compatibility
+
+## API Routing Rules
+
+Add a new API-level routing input:
+
+- `transcription_backend`
+
+Resolution order:
+
+1. explicit `transcription_backend`
+2. system-specific default if added later
+3. `DEFAULT_TRANSCRIPTION_BACKEND`
+
+Queue mapping:
+
+- `whisper` -> `transcribe_whisper`
+- `qwen` -> `transcribe_qwen`
+- `voxtral` -> `transcribe_voxtral`
+
+## Worker Behavior
+
+Each worker should consume exactly one backend queue.
+
+Examples:
+
+- `worker-whisper` consumes `transcribe_whisper`
+- `worker-qwen` consumes `transcribe_qwen`
+- `worker-voxtral` consumes `transcribe_voxtral`
+
+The worker should know:
+
+- which backend it represents
+- which queue it consumes
+- where to send inference requests
+
+Preferred inference pattern:
+
+- worker sends audio to a local or remote transcription API
+- worker normalizes the response into the existing transcript result shape
+- existing post-processing remains unchanged
+
+## Vast Autoscaling Model
+
+Vast should use the same backend-specific worker images or stacks as manual workers.
+
+The autoscaler should scale by backend queue.
+
+Examples:
+
+- backlog on `transcribe_whisper` -> launch more Whisper workers
+- backlog on `transcribe_qwen` -> launch more Qwen workers
+- backlog on `transcribe_voxtral` -> launch more Voxtral workers
+
+Suggested autoscaler env vars:
+
+- `AUTOSCALE_BACKEND=whisper|qwen|voxtral`
+- `AUTOSCALE_QUEUE=transcribe_whisper|transcribe_qwen|transcribe_voxtral`
+- `AUTOSCALE_WORKER_IMAGE=<image>`
+- `AUTOSCALE_MIN_INSTANCES=<n>`
+- `AUTOSCALE_MAX_INSTANCES=<n>`
+- `AUTOSCALE_INTERVAL=<seconds>`
+
+Operational model:
+
+- run one autoscaler per backend if needed
+- each autoscaler watches one queue
+- each autoscaler launches the worker image for that backend
+
+This keeps the logic simple and avoids one giant autoscaler trying to understand every runtime at once.
+
+## File-by-File Implementation Checklist
+
+### `backend/app/worker.py`
+
+Planned changes:
+
+- replace generic GPU queue routing with backend queue routing
+- add helper:
+  - `get_transcription_queue(backend: str) -> str`
+- update `queue_task(...)` to accept `transcription_backend`
+
+Expected queue mapping:
+
+- `whisper` -> `transcribe_whisper`
+- `qwen` -> `transcribe_qwen`
+- `voxtral` -> `transcribe_voxtral`
+
+### `backend/app/api/routes/calls.py`
+
+Planned changes:
+
+- add optional `transcription_backend`
+- default to `whisper`
+- pass backend into `worker.queue_task(...)`
+
+### `backend/app/api/routes/tasks.py`
+
+Planned changes:
+
+- add optional `transcription_backend`
+- default to `whisper`
+- pass backend into `worker.queue_task(...)`
+
+### `backend/app/api/routes/sdrtrunk.py`
+
+Planned changes:
+
+- default ingest jobs to `whisper`
+- optionally support future per-system backend overrides
+
+### `backend/app/core/config.py`
+
+Planned changes:
+
+- add:
+  - `DEFAULT_TRANSCRIPTION_BACKEND`
+  - `TRANSCRIPTION_BACKEND`
+  - `ASR_API_URL`
+  - `ASR_MODEL`
+  - `ASR_PROVIDER`
+- keep old Whisper settings temporarily
+
+### `docker/docker-entrypoint.sh`
+
+Planned changes:
+
+- keep worker startup generic
+- rely on `CELERY_QUEUES` from compose files
+- avoid backend-specific startup logic here unless strictly necessary
+
+### `docker-compose.worker-whisper.yml`
+
+Planned new file:
+
+- defines the Whisper worker stack
+- sets:
+  - `TRANSCRIPTION_BACKEND=whisper`
+  - `CELERY_QUEUES=transcribe_whisper`
+  - `ASR_API_URL=http://asr-whisper:8000/v1`
+
+### `docker-compose.worker-qwen.yml`
+
+Planned new file:
+
+- defines the Qwen worker stack
+- sets:
+  - `TRANSCRIPTION_BACKEND=qwen`
+  - `CELERY_QUEUES=transcribe_qwen`
+  - `ASR_API_URL=http://asr-qwen:8000/v1`
+
+### `docker-compose.worker-voxtral.yml`
+
+Planned new file:
+
+- defines the Voxtral worker stack
+- sets:
+  - `TRANSCRIPTION_BACKEND=voxtral`
+  - `CELERY_QUEUES=transcribe_voxtral`
+  - `ASR_API_URL=http://asr-voxtral:8000/v1` or external API config
+
+### `backend/scripts/autoscale-vast.py`
+
+Planned changes:
+
+- scale by backend queue
+- stop assuming one `WHISPER_IMPLEMENTATION` / `WHISPER_MODEL` pair
+- use:
+  - `AUTOSCALE_BACKEND`
+  - `AUTOSCALE_QUEUE`
+  - `AUTOSCALE_WORKER_IMAGE`
+
+### `docker-compose.autoscaler.yml`
+
+Planned changes:
+
+- remove Whisper-specific image naming assumptions
+- make backend image explicit
+- support one autoscaler instance per backend
+
+### `.env.example`
+
+Planned changes:
+
+- add generic backend env vars
+- move Whisper-specific env vars under a compatibility section
+- update examples to use backend-specific compose files
+
+### `README.md`
+
+Planned changes:
+
+- document setup by worker type
+- explain that multiple machines can run the same worker type and share load
+- document backend-specific compose files
+- document Vast scaling by backend queue
+
+## Suggested Service Names
+
+Worker services:
+
+- `worker-whisper`
+- `worker-qwen`
+- `worker-voxtral`
+
+Inference services:
+
+- `asr-whisper`
+- `asr-qwen`
+- `asr-voxtral`
+
+## Suggested User Flows
+
+### Add a Whisper machine
+
+1. copy `.env`
+2. select `docker-compose.worker-whisper.yml`
+3. run `docker compose up -d`
+
+### Add a Qwen machine
+
+1. copy `.env`
+2. select `docker-compose.worker-qwen.yml`
+3. run `docker compose up -d`
+
+### Add a Voxtral machine
+
+1. copy `.env`
+2. select `docker-compose.worker-voxtral.yml`
+3. run `docker compose up -d`
+
+## Recommended Implementation Order
+
+1. add backend queue routing in API and worker
+2. add generic backend env/config settings
+3. create backend-specific compose files
+4. update Vast autoscaler to scale backend queues
+5. update docs
+6. clean up old Whisper-only assumptions after the new model is working
+
+## End State
+
+After this is implemented:
+
+- any machine can join the pool by starting one backend-specific worker stack
+- the stack includes whatever is needed for inference
+- the worker consumes the backend queue automatically
+- multiple machines can run the same stack and share the load
+- Vast autoscaling launches more workers of the same backend type when that queue backs up

--- a/plans/2026-04-15-vast-ai-worker-autoscaling-approaches.md
+++ b/plans/2026-04-15-vast-ai-worker-autoscaling-approaches.md
@@ -1,0 +1,310 @@
+## Vast.ai GPU Worker Autoscaling Approaches
+
+Status: investigated
+Date: 2026-04-15
+
+### Goal
+
+Run GPU-backed transcription capacity on Vast.ai with autoscaling, while fitting the current repo architecture:
+
+- one Celery worker per backend queue
+- a separate ASR API process for GPU-backed backends
+- one autoscaler per backend queue
+
+### Current Repo Shape
+
+The current repo is already close to the desired runtime model:
+
+- the API routes jobs by backend queue in `backend/app/worker.py`
+- the worker talks to an OpenAI-compatible ASR HTTP API in `backend/app/whisper/task.py`
+- backend-specific compose files already exist for Whisper, Qwen, and Voxtral
+- `backend/scripts/autoscale-vast.py` still assumes one Vast instance runs one container with `args=["worker"]`
+
+Important local constraints:
+
+- `backend/scripts/autoscale-vast.py` launches a single container image with `args=["worker"]` and `runtype="args"` (`backend/scripts/autoscale-vast.py:334`)
+- the autoscaler sizes `CELERY_CONCURRENCY` as `floor(gpu_ram / vram_required)` (`backend/scripts/autoscale-vast.py:325`)
+- the worker no longer runs a local in-process model; it calls `ASR_API_URL` over HTTP (`backend/app/whisper/task.py:129`, `backend/app/whisper/task.py:161`)
+- the existing Whisper stack is explicitly two services, `worker-whisper` plus `asr-whisper` (`docker-compose.worker-whisper.yml:2`, `docker-compose.worker-whisper.yml:35`)
+
+That means the current autoscaler model and the current worker runtime model no longer match.
+
+### Vast.ai Constraints That Matter
+
+From current Vast.ai docs:
+
+- Docker instances run one container per instance and Vast does not support Docker-in-Docker
+- VM instances do support nested containerization and init systems like `systemd`
+- instance creation supports `template_hash_id`, `env`, `onstart`, `args`, and `vm`
+- Serverless/Deployments are request-routed HTTP systems with PyWorkers and their own autoscaling model
+
+Practical consequence:
+
+- if we want a GPU worker host to run both `celery worker` and a sibling ASR server on a normal Vast Docker instance, we need one container that supervises both processes
+- if we want to keep the repo’s current two-container compose model on Vast, we need a Vast VM, not a normal Docker instance
+
+### Approaches
+
+#### 1. Single-container GPU node on Vast Docker instances
+
+Structure:
+
+- one Vast Docker instance per GPU node
+- one custom image per backend
+- image starts both:
+  - the ASR server
+  - the Celery worker
+- supervisor can be `s6`, `supervisord`, or a small bash entrypoint with readiness checks
+
+How it maps to this repo:
+
+- keep one autoscaler per backend queue
+- keep `post_transcribe` off the GPU hosts
+- keep the current worker code mostly unchanged because it already talks to `ASR_API_URL`
+- replace backend-specific compose usage on Vast with backend-specific combined images
+
+Pros:
+
+- works with normal Vast Docker instances
+- smallest change to the current autoscaler lifecycle model
+- fastest path to production
+- cheapest operationally because Docker instances have the widest marketplace supply
+
+Cons:
+
+- the “separate ASR API” becomes a separate process, not a separate container
+- image build becomes backend-specific and heavier
+- process supervision and health signaling need to be added inside the image
+
+Assessment:
+
+- best near-term path
+- especially strong for Whisper
+- still workable for Qwen and Voxtral if each GPU host should run exactly one active transcription task at a time
+
+#### 2. Vast VM per GPU node running the existing compose stack
+
+Structure:
+
+- one Vast VM per GPU node
+- VM boots Docker / Docker Compose
+- VM runs the existing backend-specific stack, for example:
+  - `docker-compose.worker-whisper.yml`
+  - `docker-compose.worker-qwen.yml`
+  - `docker-compose.worker-voxtral.yml`
+
+How it maps to this repo:
+
+- preserves the current repo separation most faithfully
+- the autoscaler must launch VMs instead of Docker instances
+- instance startup must use `vm=true` plus `onstart` or template-based bootstrapping
+
+Pros:
+
+- preserves real container separation between worker and ASR API
+- reuses current compose files with fewer semantic changes
+- easier to debug because local and Vast layouts are almost identical
+
+Cons:
+
+- slower boot times
+- smaller pool of compatible Vast offers
+- more moving pieces during startup
+- autoscaler logic must learn VM launch behavior and probably longer readiness windows
+
+Assessment:
+
+- best if strict service separation is more important than boot speed and marketplace breadth
+- likely the cleanest long-term operational model if Qwen/Voxtral stacks keep growing
+
+#### 3. Vast Serverless / Deployments for the ASR API only
+
+Structure:
+
+- Celery workers run on CPU or ordinary compute
+- transcription requests are forwarded to a Vast Serverless endpoint or Deployment
+- Vast manages GPU worker autoscaling behind the ASR HTTP endpoint
+
+How it maps to this repo:
+
+- conceptually compatible with the worker’s HTTP-based ASR client
+- operationally different from the current queue-based instance autoscaler
+
+Pros:
+
+- Vast owns most GPU autoscaling logic
+- a clean “separate ASR API” story
+- attractive if the GPU side should become a stateless inference service
+
+Cons:
+
+- this is a larger architecture shift
+- Vast Serverless is built around endpoint traffic and PyWorker metrics, not RabbitMQ queue depth
+- request auth, readiness, cost control, and cold-start behavior all move into a different platform model
+- likely overkill for the current repo unless the ASR service is intentionally being split into a standalone product/service
+
+Assessment:
+
+- worth revisiting later
+- not the right first update to `backend/scripts/autoscale-vast.py`
+
+### Recommendation
+
+Recommended order:
+
+1. implement approach 1 for Whisper first
+2. generalize the autoscaler around “backend-specific GPU node” rather than “Celery worker owns GPU”
+3. decide per backend whether Qwen and Voxtral stay on approach 1 or move to approach 2
+
+Reasoning:
+
+- the worker already uses `ASR_API_URL`, so the repo is already decoupled at the application boundary
+- the current blocker is infrastructure packaging, not worker business logic
+- Vast Docker instances are the simplest autoscaler target, but they require one container
+- a combined image gets the autoscaler working again without forcing a VM migration immediately
+
+If strict container separation on the GPU host is a hard requirement, skip directly to approach 2.
+
+### What `autoscale-vast.py` Should Change
+
+#### 1. Model the launch target as a backend node, not a bare worker
+
+Add env/config like:
+
+- `AUTOSCALE_STACK_MODE=container|vm`
+- `AUTOSCALE_TEMPLATE_HASH=...`
+- `AUTOSCALE_DISK_GB=...`
+- `AUTOSCALE_SEARCH_PARAMS=...`
+- `AUTOSCALE_BOOT_TIMEOUT_SECONDS=...`
+
+Why:
+
+- the current script hardcodes image launch details and cannot describe VM boots or template-based launches
+
+#### 2. Stop deriving concurrency from raw VRAM for sidecar/API-backed stacks
+
+Current behavior:
+
+- `CELERY_CONCURRENCY = floor(instance["gpu_ram"] / vram_required)`
+
+Why this is wrong now:
+
+- the GPU is primarily consumed by the ASR server process, not by the Celery worker process
+- for Whisper/Qwen/Voxtral sidecar layouts, one GPU node should usually process one transcription at a time unless the specific backend server is benchmarked for safe multi-request concurrency
+
+Recommended default:
+
+- `CELERY_CONCURRENCY=1` for GPU-backed backends
+- make it overrideable via `AUTOSCALE_WORKER_CONCURRENCY`
+
+#### 3. Replace the hardcoded `RTX` filter with configurable offer selection
+
+Current behavior:
+
+- available offers are filtered to `num_gpus == 1`
+- only `gpu_name` values containing `RTX` are accepted
+
+Problems:
+
+- excludes valid datacenter GPUs like `L4`, `L40S`, `A10`, `A40`, `H100`
+- forces one GPU even if a backend might later benefit from a different shape
+
+Recommended:
+
+- let `AUTOSCALE_SEARCH_PARAMS` drive offer selection
+- still keep guardrails for:
+  - minimum VRAM
+  - CUDA compatibility
+  - reliability
+  - direct ports / networking if needed
+
+#### 4. Prefer Vast templates over raw inline launch bodies
+
+Use `template_hash_id` where possible.
+
+Why:
+
+- Vast templates can hold image, env defaults, ports, launch mode, and provisioning choices
+- the autoscaler should mostly choose capacity, not reconstruct the full machine definition every time
+- request-level env can still override template values when needed
+
+#### 5. Add backend-specific readiness handling
+
+The current deletion logic treats long `loading` windows as bad after 20 minutes.
+
+That is too naive for model-heavy ASR stacks because first boot may include:
+
+- image pull
+- model download
+- backend warmup
+
+Recommended:
+
+- separate “instance exists” from “worker ready”
+- track:
+  - instance status from Vast
+  - Celery worker registration
+  - optional ASR readiness endpoint
+- make loading timeout backend-specific
+
+#### 6. Identify managed instances by label, not only env matching
+
+Current matching is based on `CELERY_BROKER_URL` and `CELERY_QUEUES`.
+
+Recommended:
+
+- add an explicit label such as `tt-whisper-prod`
+- use that label plus queue/env checks when listing or deleting instances
+
+This makes cleanup safer when more than one environment shares the same broker.
+
+### Suggested Backend Rollout
+
+#### Whisper
+
+Recommended now:
+
+- combined GPU image containing `speaches` + the Celery worker
+- one request at a time per GPU node by default
+- repo autoscaler remains the source of truth
+
+#### Qwen
+
+Recommended now:
+
+- start with the same combined-image pattern if the Qwen server is stable enough in one container
+- otherwise use the VM approach once the autoscaler supports `vm=true`
+
+#### Voxtral
+
+Recommended now:
+
+- likely the strongest candidate for a VM-based stack if vLLM tuning, caching, or additional sidecars keep growing
+- if kept on Docker instances, treat it as one GPU node per active request unless benchmarks prove otherwise
+
+#### API backend
+
+Do not use Vast GPU autoscaling for `api`.
+
+- it is forwarding-only in the current repo
+- keep it on ordinary CPU compute
+
+### Implementation Sequence
+
+1. Add a planning abstraction to `autoscale-vast.py` for backend node launch config.
+2. Add support for `AUTOSCALE_WORKER_CONCURRENCY` and default GPU-backed backends to `1`.
+3. Add support for template-based launches and configurable search filters.
+4. Add instance labels and safer instance discovery.
+5. Build one combined Whisper GPU image for Vast.
+6. Prove the Whisper path end to end.
+7. Decide whether Qwen and Voxtral should use combined images or VMs.
+
+### Sources
+
+- Vast Docker execution environment: https://docs.vast.ai/documentation/instances/docker-environment
+- Vast instances FAQ: https://docs.vast.ai/documentation/reference/faq/instances
+- Vast virtual machines: https://docs.vast.ai/documentation/instances/virtual-machines
+- Vast create instance API: https://docs.vast.ai/api-reference/instances/create-instance
+- Vast serverless architecture: https://docs.vast.ai/documentation/serverless/architecture
+- Vast deployments overview: https://docs.vast.ai/documentation/serverless/deployments
+- Vast serverless getting started: https://docs.vast.ai/documentation/serverless/getting-started-with-serverless


### PR DESCRIPTION
Adds `docs/sirens-linear-execution-plan.md` as the implementation sequencing guide for the current Sirens Linear tranche, plus the companion `crimeisdown-site-product-spec.md` and backend planning notes under `plans/`. Also updates `docs/README.md` to index the new docs.