### PR TITLE
Frontend: add provider boundaries + default adapters for Sirens tranche

### DIFF
--- a/frontend/src/components/SavedTranscriptSearches.tsx
+++ b/frontend/src/components/SavedTranscriptSearches.tsx
@@ -7,16 +7,13 @@ import { useInstantSearch } from 'react-instantsearch'
 
 import {
   buildTranscriptSavedSearchUrl,
-  createTranscriptSavedSearchEntry,
   deleteTranscriptSavedSearchEntry,
   describeTranscriptSavedSearchState,
   extractTranscriptSavedSearchState,
-  loadTranscriptSavedSearches,
-  persistTranscriptSavedSearches,
-  updateTranscriptSavedSearchEntry,
   upsertTranscriptSavedSearchEntry,
   type TranscriptSavedSearchEntry,
 } from '@/lib/transcriptSavedSearches'
+import { useSavedSearchStore } from '@/providers/savedSearchStore'
 
 function formatSavedSearchTimestamp(timestamp: string): string {
   const parsed = new Date(timestamp)
@@ -29,13 +26,28 @@ export default function SavedTranscriptSearches({
   indexName: string
 }) {
   const { indexUiState, setUiState } = useInstantSearch<UiState>()
+  const savedSearchStore = useSavedSearchStore()
   const [savedSearches, setSavedSearches] = useState<TranscriptSavedSearchEntry[]>(
     [],
   )
 
   useEffect(() => {
-    setSavedSearches(loadTranscriptSavedSearches())
-  }, [])
+    let isActive = true
+    savedSearchStore
+      .list()
+      .then((entries) => {
+        if (isActive) {
+          setSavedSearches(entries)
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load saved searches', error)
+      })
+
+    return () => {
+      isActive = false
+    }
+  }, [savedSearchStore])
 
   const currentState = useMemo(
     () =>
@@ -50,12 +62,7 @@ export default function SavedTranscriptSearches({
     [currentState],
   )
 
-  const persistSavedSearches = (nextSavedSearches: TranscriptSavedSearchEntry[]) => {
-    const normalized = persistTranscriptSavedSearches(nextSavedSearches)
-    setSavedSearches(normalized)
-  }
-
-  const saveCurrentSearch = () => {
+  const saveCurrentSearch = async () => {
     if (typeof window === 'undefined') {
       return
     }
@@ -66,11 +73,14 @@ export default function SavedTranscriptSearches({
       return
     }
 
-    const nextEntry = createTranscriptSavedSearchEntry(name, indexUiState as Record<
-      string,
-      unknown
-    >)
-    persistSavedSearches([...savedSearches, nextEntry])
+    try {
+      const created = await savedSearchStore.create(name, currentState)
+      setSavedSearches((currentEntries) =>
+        upsertTranscriptSavedSearchEntry(currentEntries, created),
+      )
+    } catch (error) {
+      console.error('Failed to create saved search', error)
+    }
   }
 
   const openSavedSearch = (entry: TranscriptSavedSearchEntry) => {
@@ -82,7 +92,7 @@ export default function SavedTranscriptSearches({
     }))
   }
 
-  const updateSavedSearch = (entry: TranscriptSavedSearchEntry) => {
+  const updateSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
     const shouldUpdate =
       typeof window === 'undefined'
         ? true
@@ -92,19 +102,17 @@ export default function SavedTranscriptSearches({
       return
     }
 
-    const updatedEntry = updateTranscriptSavedSearchEntry(
-      entry,
-      indexUiState as Record<string, unknown>,
-    )
-    persistSavedSearches(
-      upsertTranscriptSavedSearchEntry(
-        savedSearches,
-        updatedEntry,
-      ),
-    )
+    try {
+      const updated = await savedSearchStore.update(entry.id, currentState)
+      setSavedSearches((currentEntries) =>
+        upsertTranscriptSavedSearchEntry(currentEntries, updated),
+      )
+    } catch (error) {
+      console.error('Failed to update saved search', error)
+    }
   }
 
-  const removeSavedSearch = (entry: TranscriptSavedSearchEntry) => {
+  const removeSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
     const shouldDelete =
       typeof window === 'undefined'
         ? true
@@ -114,7 +122,14 @@ export default function SavedTranscriptSearches({
       return
     }
 
-    persistSavedSearches(deleteTranscriptSavedSearchEntry(savedSearches, entry.id))
+    try {
+      await savedSearchStore.remove(entry.id)
+      setSavedSearches((currentEntries) =>
+        deleteTranscriptSavedSearchEntry(currentEntries, entry.id),
+      )
+    } catch (error) {
+      console.error('Failed to remove saved search', error)
+    }
   }
 
   return (
@@ -221,4 +236,3 @@ export default function SavedTranscriptSearches({
     </div>
   )
 }
-

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -42,20 +42,13 @@ import {
 	transformCurrentRefinements,
 	transformHierarchyMenuItems,
 	transformSystemRefinementItems,
-} from "@/lib/transcriptSearchLabels";
+	} from "@/lib/transcriptSearchLabels";
+import { useTranscriptSearchCredentials } from "@/hooks/useTranscriptSearchCredentials";
 import CallTimeRangeFilter from "./CallTimeRangeFilter";
 import SearchAnalysisPanel from "./chat/SearchAnalysisPanel";
 import { Hit as HitComponent } from "./Hit";
 import SavedTranscriptSearches from "./SavedTranscriptSearches";
 
-const hostUrl = import.meta.env.VITE_MEILI_URL || "http://localhost:7700";
-const apiKey = import.meta.env.VITE_MEILI_MASTER_KEY || "testing";
-const baseIndexName = import.meta.env.VITE_MEILI_INDEX || "calls";
-const splitByMonth = import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === "true";
-const archiveIndexConfig: TranscriptSearchIndexConfig = {
-	baseIndexName,
-	splitByMonth,
-};
 const AUTO_REFRESH_INTERVAL_MS = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -141,12 +134,19 @@ function TranscriptArchiveIndexNotice({
 	baseIndexName: string;
 	indexName: string;
 	splitByMonth: boolean;
-}) {
-	const { indexUiState } = useInstantSearch<UiState>();
-	const currentMonthIndexName = useMemo(
-		() => getTranscriptCurrentMonthIndexName(archiveIndexConfig),
-		[baseIndexName, splitByMonth],
-	);
+	}) {
+		const { indexUiState } = useInstantSearch<UiState>();
+		const archiveIndexConfig: TranscriptSearchIndexConfig = useMemo(
+			() => ({
+				baseIndexName,
+				splitByMonth,
+			}),
+			[baseIndexName, splitByMonth],
+		);
+		const currentMonthIndexName = useMemo(
+			() => getTranscriptCurrentMonthIndexName(archiveIndexConfig),
+			[archiveIndexConfig],
+		);
 	const indexState = (indexUiState || {}) as Record<string, unknown>;
 	const searchScope = useMemo(
 		() => extractScannerSearchScope(indexState),
@@ -376,32 +376,69 @@ function SearchToolbarActions({ indexName }: { indexName: string }) {
 	);
 }
 
-const SearchComponent = () => {
-	const searchClient = instantMeiliSearch(hostUrl, apiKey).searchClient;
-	const searchLocationSearch =
-		typeof window === "undefined" ? "" : window.location.search;
-	const indexName = getTranscriptSearchIndexNameFromLocation(
-		searchLocationSearch,
-		archiveIndexConfig,
-	);
+	const SearchComponent = () => {
+		const { credentials, error, isLoading } = useTranscriptSearchCredentials();
+		const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
+			if (!credentials) {
+				return null;
+			}
 
-	const [filtersOpen, setFiltersOpen] = useState(true);
-	const [selectedHitId, setSelectedHitId] = useState<string | undefined>(() =>
-		typeof window === "undefined"
+			return {
+				baseIndexName: credentials.baseIndexName,
+				splitByMonth: credentials.splitByMonth,
+			};
+		}, [credentials]);
+		const searchClient = useMemo(() => {
+			if (!credentials) {
+				return null;
+			}
+
+			return instantMeiliSearch(credentials.hostUrl, credentials.apiKey).searchClient;
+		}, [credentials]);
+		const searchLocationSearch =
+			typeof window === "undefined" ? "" : window.location.search;
+		const indexName =
+			archiveIndexConfig === null
+				? ""
+				: getTranscriptSearchIndexNameFromLocation(
+						searchLocationSearch,
+						archiveIndexConfig,
+					);
+
+		const [filtersOpen, setFiltersOpen] = useState(true);
+		const [selectedHitId, setSelectedHitId] = useState<string | undefined>(() =>
+			typeof window === "undefined"
 			? undefined
 			: parseSelectedHitId(window.location.hash),
 	);
 
 	let timer: ReturnType<typeof setTimeout>;
-	const queryHook = (query: string, refine: (nextQuery: string) => void) => {
-		clearTimeout(timer);
-		timer = setTimeout(() => refine(query), 500);
-	};
+		const queryHook = (query: string, refine: (nextQuery: string) => void) => {
+			clearTimeout(timer);
+			timer = setTimeout(() => refine(query), 500);
+		};
 
-	const routing = {
-		router: history({
-			windowTitle: (routeState) => {
-				const indexState = routeState[indexName] || {};
+		if (isLoading) {
+			return (
+				<Alert variant="secondary" className="m-3">
+					Loading transcript search…
+				</Alert>
+			);
+		}
+
+		if (!credentials || !archiveIndexConfig || !searchClient) {
+			return (
+				<Alert variant="danger" className="m-3">
+					Failed to load search credentials.
+					{error ? <div className="small mt-2">{error.message}</div> : null}
+				</Alert>
+			);
+		}
+
+		const routing = {
+			router: history({
+				windowTitle: (routeState) => {
+					const indexState = routeState[indexName] || {};
 
 				if (!indexState.query) {
 					return "Search Scanner Transcripts";
@@ -410,17 +447,17 @@ const SearchComponent = () => {
 				return `${indexState.query} - Search Scanner Transcripts`;
 			},
 			parseURL: ({ qsModule, location }): UiState => {
-				const routeState = qsModule.parse(location.search.slice(1), {
-					arrayLimit: 99,
-				}) as unknown as UiState;
+					const routeState = qsModule.parse(location.search.slice(1), {
+						arrayLimit: 99,
+					}) as unknown as UiState;
 
-				if (splitByMonth && Object.keys(routeState).length) {
-					return remapSearchStateIndex(
-						routeState,
-						baseIndexName,
-						indexName,
-					);
-				}
+					if (credentials.splitByMonth && Object.keys(routeState).length) {
+						return remapSearchStateIndex(
+							routeState,
+							credentials.baseIndexName,
+							indexName,
+						);
+					}
 
 				if (!Object.keys(routeState).length) {
 					const defaultSort = `${indexName}:start_time:desc`;
@@ -673,12 +710,12 @@ const SearchComponent = () => {
 						</div>
 					</Collapse>
 				</Col>
-				<Col className="search-panel__results">
-					<TranscriptArchiveIndexNotice
-						baseIndexName={baseIndexName}
-						indexName={indexName}
-						splitByMonth={splitByMonth}
-					/>
+					<Col className="search-panel__results">
+						<TranscriptArchiveIndexNotice
+							baseIndexName={credentials.baseIndexName}
+							indexName={indexName}
+							splitByMonth={credentials.splitByMonth}
+						/>
 					<TranscriptSearchResults
 						indexName={indexName}
 						selectedHitId={selectedHitId}

--- a/frontend/src/components/TranscriptMap.tsx
+++ b/frontend/src/components/TranscriptMap.tsx
@@ -42,17 +42,9 @@ import {
   transformCurrentRefinements,
   transformSystemRefinementItems,
 } from '@/lib/transcriptSearchLabels'
+import { useTranscriptSearchCredentials } from '@/hooks/useTranscriptSearchCredentials'
 import CallTimeRangeFilter from './CallTimeRangeFilter'
 import { Hit as HitComponent } from './Hit'
-
-const hostUrl = import.meta.env.VITE_MEILI_URL || 'http://localhost:7700'
-const apiKey = import.meta.env.VITE_MEILI_MASTER_KEY || 'testing'
-const baseIndexName = import.meta.env.VITE_MEILI_INDEX || 'calls'
-const splitByMonth = import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === 'true'
-const archiveIndexConfig: TranscriptSearchIndexConfig = {
-  baseIndexName,
-  splitByMonth,
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -302,13 +294,50 @@ function TranscriptMapResults({ indexName }: { indexName: string }) {
 }
 
 export default function TranscriptMap() {
-  const searchClient = instantMeiliSearch(hostUrl, apiKey).searchClient
+  const { credentials, error, isLoading } = useTranscriptSearchCredentials()
+  const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
+    if (!credentials) {
+      return null
+    }
+
+    return {
+      baseIndexName: credentials.baseIndexName,
+      splitByMonth: credentials.splitByMonth,
+    }
+  }, [credentials])
+  const searchClient = useMemo(() => {
+    if (!credentials) {
+      return null
+    }
+
+    return instantMeiliSearch(credentials.hostUrl, credentials.apiKey).searchClient
+  }, [credentials])
   const searchLocationSearch =
     typeof window === 'undefined' ? '' : window.location.search
-  const indexName = getTranscriptSearchIndexNameFromLocation(
-    searchLocationSearch,
-    archiveIndexConfig,
-  )
+  const indexName =
+    archiveIndexConfig === null
+      ? ''
+      : getTranscriptSearchIndexNameFromLocation(
+          searchLocationSearch,
+          archiveIndexConfig,
+        )
+
+  if (isLoading) {
+    return (
+      <Alert variant="secondary" className="m-3">
+        Loading transcript map…
+      </Alert>
+    )
+  }
+
+  if (!credentials || !archiveIndexConfig || !searchClient) {
+    return (
+      <Alert variant="danger" className="m-3">
+        Failed to load search credentials.
+        {error ? <div className="small mt-2">{error.message}</div> : null}
+      </Alert>
+    )
+  }
 
   const routing = {
     router: history({
@@ -326,8 +355,12 @@ export default function TranscriptMap() {
           arrayLimit: 99,
         }) as unknown as UiState
 
-        if (splitByMonth && Object.keys(routeState).length) {
-          return remapSearchStateIndex(routeState, baseIndexName, indexName)
+        if (credentials.splitByMonth && Object.keys(routeState).length) {
+          return remapSearchStateIndex(
+            routeState,
+            credentials.baseIndexName,
+            indexName,
+          )
         }
 
         if (!Object.keys(routeState).length) {

--- a/frontend/src/hooks/useTranscriptSearchCredentials.ts
+++ b/frontend/src/hooks/useTranscriptSearchCredentials.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+	useSearchCredentialProvider,
+	type TranscriptSearchCredentials,
+} from "@/providers/searchCredentials";
+
+export type UseTranscriptSearchCredentialsResult = {
+	credentials: TranscriptSearchCredentials | null;
+	error: Error | null;
+	isLoading: boolean;
+	refresh: () => void;
+};
+
+function asError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+export function useTranscriptSearchCredentials(): UseTranscriptSearchCredentialsResult {
+	const provider = useSearchCredentialProvider();
+	const [credentials, setCredentials] = useState<TranscriptSearchCredentials | null>(
+		null,
+	);
+	const [error, setError] = useState<Error | null>(null);
+	const [refreshToken, setRefreshToken] = useState(0);
+
+	const refresh = useCallback(() => {
+		setRefreshToken((value) => value + 1);
+	}, []);
+
+	useEffect(() => {
+		let isActive = true;
+		setError(null);
+
+		provider
+			.getTranscriptSearchCredentials()
+			.then((nextCredentials) => {
+				if (!isActive) {
+					return;
+				}
+				setCredentials(nextCredentials);
+			})
+			.catch((caught) => {
+				if (!isActive) {
+					return;
+				}
+				setError(asError(caught));
+			});
+
+		return () => {
+			isActive = false;
+		};
+	}, [provider, refreshToken]);
+
+	return {
+		credentials,
+		error,
+		isLoading: !credentials && !error,
+		refresh,
+	};
+}
+

--- a/frontend/src/lib/transcriptSavedSearches.ts
+++ b/frontend/src/lib/transcriptSavedSearches.ts
@@ -160,16 +160,38 @@ export function persistTranscriptSavedSearches(
   return normalizedEntries
 }
 
-export function createTranscriptSavedSearchEntry(
+export function createTranscriptSavedSearchEntryFromState(
   name: string,
-  indexUiState: Record<string, unknown> | undefined,
+  state: ScannerSearchUiState,
 ): TranscriptSavedSearchEntry {
   const now = new Date().toISOString()
   return {
     id: generateSavedSearchId(),
     name: normalizeSavedSearchName(name),
-    state: extractTranscriptSavedSearchState(indexUiState),
+    state,
     createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export function createTranscriptSavedSearchEntry(
+  name: string,
+  indexUiState: Record<string, unknown> | undefined,
+): TranscriptSavedSearchEntry {
+  return createTranscriptSavedSearchEntryFromState(
+    name,
+    extractTranscriptSavedSearchState(indexUiState),
+  )
+}
+
+export function updateTranscriptSavedSearchEntryFromState(
+  entry: TranscriptSavedSearchEntry,
+  state: ScannerSearchUiState,
+): TranscriptSavedSearchEntry {
+  const now = new Date().toISOString()
+  return {
+    ...entry,
+    state,
     updatedAt: now,
   }
 }
@@ -178,12 +200,10 @@ export function updateTranscriptSavedSearchEntry(
   entry: TranscriptSavedSearchEntry,
   indexUiState: Record<string, unknown> | undefined,
 ): TranscriptSavedSearchEntry {
-  const now = new Date().toISOString()
-  return {
-    ...entry,
-    state: extractTranscriptSavedSearchState(indexUiState),
-    updatedAt: now,
-  }
+  return updateTranscriptSavedSearchEntryFromState(
+    entry,
+    extractTranscriptSavedSearchState(indexUiState),
+  )
 }
 
 export function upsertTranscriptSavedSearchEntry(
@@ -202,4 +222,3 @@ export function deleteTranscriptSavedSearchEntry(
 ): TranscriptSavedSearchEntry[] {
   return sortSavedSearches(entries.filter((entry) => entry.id !== id))
 }
-

--- a/frontend/src/providers/AppProviders.tsx
+++ b/frontend/src/providers/AppProviders.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+import { AuthProvider } from "./auth";
+import { EntitlementsProvider } from "./entitlements";
+import { NotificationsProvider } from "./notifications";
+import { SavedSearchStoreProvider } from "./savedSearchStore";
+import { SearchCredentialsProvider } from "./searchCredentials";
+import { ViewerProvider } from "./viewer";
+
+export function AppProviders({ children }: { children: ReactNode }) {
+	return (
+		<AuthProvider>
+			<ViewerProvider>
+				<EntitlementsProvider>
+					<SearchCredentialsProvider>
+						<SavedSearchStoreProvider>
+							<NotificationsProvider>{children}</NotificationsProvider>
+						</SavedSearchStoreProvider>
+					</SearchCredentialsProvider>
+				</EntitlementsProvider>
+			</ViewerProvider>
+		</AuthProvider>
+	);
+}
+

--- a/frontend/src/providers/auth.tsx
+++ b/frontend/src/providers/auth.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type AuthStatus = "anonymous" | "authenticated" | "loading";
+
+export type AuthProvider = {
+	status: AuthStatus;
+	getAccessToken: () => Promise<string | null>;
+	signIn: () => Promise<void>;
+	signOut: () => Promise<void>;
+};
+
+const defaultAuthProvider: AuthProvider = {
+	status: "anonymous",
+	async getAccessToken() {
+		return null;
+	},
+	async signIn() {},
+	async signOut() {},
+};
+
+const AuthContext = createContext<AuthProvider>(defaultAuthProvider);
+
+export function AuthProvider({
+	children,
+	provider,
+}: {
+	children: ReactNode;
+	provider?: AuthProvider;
+}) {
+	return (
+		<AuthContext.Provider value={provider ?? defaultAuthProvider}>
+			{children}
+		</AuthContext.Provider>
+	);
+}
+
+export function useAuth(): AuthProvider {
+	return useContext(AuthContext);
+}
+

--- a/frontend/src/providers/entitlements.tsx
+++ b/frontend/src/providers/entitlements.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type EntitlementsService = {
+	canSearchTranscripts: () => boolean;
+	canCreateAlerts: () => boolean;
+};
+
+const defaultEntitlementsService: EntitlementsService = {
+	canSearchTranscripts: () => true,
+	canCreateAlerts: () => false,
+};
+
+const EntitlementsContext = createContext<EntitlementsService>(
+	defaultEntitlementsService,
+);
+
+export function EntitlementsProvider({
+	children,
+	service,
+}: {
+	children: ReactNode;
+	service?: EntitlementsService;
+}) {
+	return (
+		<EntitlementsContext.Provider
+			value={service ?? defaultEntitlementsService}
+		>
+			{children}
+		</EntitlementsContext.Provider>
+	);
+}
+
+export function useEntitlements(): EntitlementsService {
+	return useContext(EntitlementsContext);
+}
+

--- a/frontend/src/providers/notifications.tsx
+++ b/frontend/src/providers/notifications.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type NotificationLevel = "info" | "success" | "warning" | "error";
+
+export type NotificationStore = {
+	notify: (level: NotificationLevel, message: string) => void;
+};
+
+const defaultNotificationStore: NotificationStore = {
+	notify: () => {},
+};
+
+const NotificationContext = createContext<NotificationStore>(
+	defaultNotificationStore,
+);
+
+export function NotificationsProvider({
+	children,
+	store,
+}: {
+	children: ReactNode;
+	store?: NotificationStore;
+}) {
+	return (
+		<NotificationContext.Provider value={store ?? defaultNotificationStore}>
+			{children}
+		</NotificationContext.Provider>
+	);
+}
+
+export function useNotifications(): NotificationStore {
+	return useContext(NotificationContext);
+}
+

--- a/frontend/src/providers/savedSearchStore.tsx
+++ b/frontend/src/providers/savedSearchStore.tsx
@@ -1,0 +1,89 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { ScannerSearchUiState } from "@/lib/searchState";
+import {
+	createTranscriptSavedSearchEntryFromState,
+	deleteTranscriptSavedSearchEntry,
+	loadTranscriptSavedSearches,
+	persistTranscriptSavedSearches,
+	updateTranscriptSavedSearchEntryFromState,
+	upsertTranscriptSavedSearchEntry,
+	type TranscriptSavedSearchEntry,
+} from "@/lib/transcriptSavedSearches";
+
+export type SavedSearchStore = {
+	list: () => Promise<TranscriptSavedSearchEntry[]>;
+	create: (
+		name: string,
+		state: ScannerSearchUiState,
+	) => Promise<TranscriptSavedSearchEntry>;
+	update: (
+		id: string,
+		state: ScannerSearchUiState,
+	) => Promise<TranscriptSavedSearchEntry>;
+	remove: (id: string) => Promise<void>;
+};
+
+export type SavedSearchStorage = Parameters<typeof loadTranscriptSavedSearches>[0];
+
+export function createLocalStorageSavedSearchStore(
+	storage?: SavedSearchStorage,
+): SavedSearchStore {
+	return {
+		async list() {
+			return loadTranscriptSavedSearches(storage);
+		},
+
+		async create(name, state) {
+			const entries = loadTranscriptSavedSearches(storage);
+			const created = createTranscriptSavedSearchEntryFromState(name, state);
+			persistTranscriptSavedSearches([...entries, created], storage);
+			return created;
+		},
+
+		async update(id, state) {
+			const entries = loadTranscriptSavedSearches(storage);
+			const existing = entries.find((entry) => entry.id === id);
+			if (!existing) {
+				throw new Error(`Saved search not found: ${id}`);
+			}
+
+			const updated = updateTranscriptSavedSearchEntryFromState(existing, state);
+			persistTranscriptSavedSearches(
+				upsertTranscriptSavedSearchEntry(entries, updated),
+				storage,
+			);
+			return updated;
+		},
+
+		async remove(id) {
+			const entries = loadTranscriptSavedSearches(storage);
+			persistTranscriptSavedSearches(deleteTranscriptSavedSearchEntry(entries, id), storage);
+		},
+	};
+}
+
+const defaultSavedSearchStore = createLocalStorageSavedSearchStore();
+
+const SavedSearchStoreContext = createContext<SavedSearchStore>(
+	defaultSavedSearchStore,
+);
+
+export function SavedSearchStoreProvider({
+	children,
+	store,
+}: {
+	children: ReactNode;
+	store?: SavedSearchStore;
+}) {
+	return (
+		<SavedSearchStoreContext.Provider value={store ?? defaultSavedSearchStore}>
+			{children}
+		</SavedSearchStoreContext.Provider>
+	);
+}
+
+export function useSavedSearchStore(): SavedSearchStore {
+	return useContext(SavedSearchStoreContext);
+}
+

--- a/frontend/src/providers/searchCredentials.tsx
+++ b/frontend/src/providers/searchCredentials.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type TranscriptSearchCredentials = {
+	hostUrl: string;
+	apiKey: string;
+	baseIndexName: string;
+	splitByMonth: boolean;
+};
+
+export type SearchCredentialProvider = {
+	getTranscriptSearchCredentials: () => Promise<TranscriptSearchCredentials>;
+};
+
+export function createEnvSearchCredentialProvider(): SearchCredentialProvider {
+	return {
+		async getTranscriptSearchCredentials() {
+			return {
+				hostUrl: import.meta.env.VITE_MEILI_URL || "http://localhost:7700",
+				apiKey: import.meta.env.VITE_MEILI_MASTER_KEY || "testing",
+				baseIndexName: import.meta.env.VITE_MEILI_INDEX || "calls",
+				splitByMonth: import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === "true",
+			};
+		},
+	};
+}
+
+const defaultSearchCredentialProvider = createEnvSearchCredentialProvider();
+
+const SearchCredentialContext = createContext<SearchCredentialProvider>(
+	defaultSearchCredentialProvider,
+);
+
+export function SearchCredentialsProvider({
+	children,
+	provider,
+}: {
+	children: ReactNode;
+	provider?: SearchCredentialProvider;
+}) {
+	return (
+		<SearchCredentialContext.Provider
+			value={provider ?? defaultSearchCredentialProvider}
+		>
+			{children}
+		</SearchCredentialContext.Provider>
+	);
+}
+
+export function useSearchCredentialProvider(): SearchCredentialProvider {
+	return useContext(SearchCredentialContext);
+}
+

--- a/frontend/src/providers/viewer.tsx
+++ b/frontend/src/providers/viewer.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type Viewer = {
+	id: string;
+	displayName?: string;
+	email?: string;
+};
+
+export type ViewerProvider = {
+	viewer: Viewer | null;
+	refresh: () => Promise<void>;
+};
+
+const defaultViewerProvider: ViewerProvider = {
+	viewer: null,
+	async refresh() {},
+};
+
+const ViewerContext = createContext<ViewerProvider>(defaultViewerProvider);
+
+export function ViewerProvider({
+	children,
+	provider,
+}: {
+	children: ReactNode;
+	provider?: ViewerProvider;
+}) {
+	return (
+		<ViewerContext.Provider value={provider ?? defaultViewerProvider}>
+			{children}
+		</ViewerContext.Provider>
+	);
+}
+
+export function useViewer(): ViewerProvider {
+	return useContext(ViewerContext);
+}
+

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { TanStackDevtools } from '@tanstack/react-devtools'
 import type { ReactNode } from 'react'
 
 import Header from '../components/Header'
+import { AppProviders } from '../providers/AppProviders'
 
 import appCss from '../styles.css?url'
 import copilotCss from '@copilotkit/react-ui/styles.css?url'
@@ -64,20 +65,22 @@ function RootDocument({ children }: { children: ReactNode }) {
           agent="scanner_chat"
           showDevConsole={import.meta.env.DEV}
         >
-          <Header />
-          {children}
-          <TanStackDevtools
-            config={{
-              position: 'bottom-left',
-            }}
-            plugins={[
-              {
-                name: 'Tanstack Router',
-                render: <TanStackRouterDevtoolsPanel />,
-              },
-            ]}
-          />
-          <Scripts />
+          <AppProviders>
+            <Header />
+            {children}
+            <TanStackDevtools
+              config={{
+                position: 'bottom-left',
+              }}
+              plugins={[
+                {
+                  name: 'Tanstack Router',
+                  render: <TanStackRouterDevtoolsPanel />,
+                },
+              ]}
+            />
+            <Scripts />
+          </AppProviders>
         </CopilotKit>
       </body>
     </html>


### PR DESCRIPTION
Implements `CRI-63` foundation work by introducing provider/context boundaries for auth, viewer, entitlements, saved searches, notifications, and search credentials, with default anonymous/localStorage/env adapters to preserve current OSS behavior.

Also refactors `Search`, `TranscriptMap`, and saved-search UI to consume the provider interfaces (credentials now load via `SearchCredentialProvider`; saved searches via `SavedSearchStore`).

Local verification: `cd frontend && npm test`.