### PR TITLE
Frontend: capability contract + capability-based gating (CRI-65)

### DIFF
--- a/frontend/src/components/CallTimeRangeFilter.tsx
+++ b/frontend/src/components/CallTimeRangeFilter.tsx
@@ -1,103 +1,153 @@
-'use client'
+"use client";
 
-import { useEffect, useState } from 'react'
-import { Col, Row } from 'react-bootstrap'
-import { FaCalendar } from 'react-icons/fa'
-import { useRange } from 'react-instantsearch'
+import { useEffect, useState } from "react";
+import { Col, Row } from "react-bootstrap";
+import { FaCalendar } from "react-icons/fa";
+import { useRange } from "react-instantsearch";
 
 import {
-  clampTranscriptSearchRangeToMonth,
-  type TranscriptSearchIndexConfig,
-} from '@/lib/transcriptSearchIndex'
+	clampTranscriptSearchRangeToMonth,
+	type TranscriptSearchIndexConfig,
+} from "@/lib/transcriptSearchIndex";
 import {
-  epochSecondsToLocalDateTimeValue,
-  toEpochSeconds,
-} from '@/lib/searchState'
+	epochSecondsToLocalDateTimeValue,
+	toEpochSeconds,
+} from "@/lib/searchState";
 
 type CallTimeRangeFilterProps = {
-  archiveConfig?: TranscriptSearchIndexConfig
-}
+	archiveConfig?: TranscriptSearchIndexConfig;
+	archiveDepthDays?: number | null;
+};
 
 export default function CallTimeRangeFilter({
-  archiveConfig,
+	archiveConfig,
+	archiveDepthDays,
 }: CallTimeRangeFilterProps) {
-  const { start, refine } = useRange({
-    attribute: 'start_time',
-  })
+	const { start, refine } = useRange({
+		attribute: "start_time",
+	});
 
-  const [minValue, setMinValue] = useState('')
-  const [maxValue, setMaxValue] = useState('')
+	const [minValue, setMinValue] = useState("");
+	const [maxValue, setMaxValue] = useState("");
 
-  useEffect(() => {
-    setMinValue(epochSecondsToLocalDateTimeValue(start[0]))
-  }, [start[0]])
+	useEffect(() => {
+		setMinValue(epochSecondsToLocalDateTimeValue(start[0]));
+	}, [start[0]]);
 
-  useEffect(() => {
-    setMaxValue(epochSecondsToLocalDateTimeValue(start[1]))
-  }, [start[1]])
+	useEffect(() => {
+		setMaxValue(epochSecondsToLocalDateTimeValue(start[1]));
+	}, [start[1]]);
 
-  const updateRange = (nextMinValue: string, nextMaxValue: string) => {
-    const nextMin = toEpochSeconds(nextMinValue)
-    const nextMax = toEpochSeconds(nextMaxValue)
-    const nextRange = `${nextMin ?? ''}:${nextMax ?? ''}`
+	const normalizedArchiveDepthDays =
+		typeof archiveDepthDays === "number" &&
+		Number.isFinite(archiveDepthDays) &&
+		archiveDepthDays > 0
+			? Math.floor(archiveDepthDays)
+			: null;
 
-    if (archiveConfig?.splitByMonth && nextMin !== undefined) {
-      const clampedRange = clampTranscriptSearchRangeToMonth(nextRange)
-      if (clampedRange) {
-        const [clampedMin, clampedMax] = clampedRange.split(':', 2)
-        const clampedMinValue = Number.parseInt(clampedMin || '', 10)
-        const clampedMaxValue = Number.parseInt(clampedMax || '', 10)
-        refine([
-          Number.isFinite(clampedMinValue) ? clampedMinValue : undefined,
-          Number.isFinite(clampedMaxValue) ? clampedMaxValue : undefined,
-        ])
-      }
-      return
-    }
+	const minAllowedEpochSeconds =
+		normalizedArchiveDepthDays === null
+			? undefined
+			: Math.floor(Date.now() / 1000) -
+				normalizedArchiveDepthDays * 24 * 60 * 60;
 
-    refine([nextMin, nextMax])
-  }
+	const minAllowedInputValue = epochSecondsToLocalDateTimeValue(
+		minAllowedEpochSeconds,
+	);
 
-  return (
-    <Row>
-      <Col>
-        <label htmlFor="minStartTime">From Time</label>
-        <div className="input-group date">
-          <input
-            type="datetime-local"
-            id="minStartTime"
-            className="form-control"
-            value={minValue}
-            onChange={(event) => {
-              const nextValue = event.target.value
-              setMinValue(nextValue)
-              updateRange(nextValue, maxValue)
-            }}
-          />
-          <span className="input-group-text">
-            <FaCalendar />
-          </span>
-        </div>
-      </Col>
-      <Col>
-        <label htmlFor="maxStartTime">To Time</label>
-        <div className="input-group date">
-          <input
-            type="datetime-local"
-            id="maxStartTime"
-            className="form-control"
-            value={maxValue}
-            onChange={(event) => {
-              const nextValue = event.target.value
-              setMaxValue(nextValue)
-              updateRange(minValue, nextValue)
-            }}
-          />
-          <span className="input-group-text">
-            <FaCalendar />
-          </span>
-        </div>
-      </Col>
-    </Row>
-  )
+	const clampEpochSeconds = (value: number | undefined): number | undefined => {
+		if (value === undefined || minAllowedEpochSeconds === undefined) {
+			return value;
+		}
+
+		return Math.max(value, minAllowedEpochSeconds);
+	};
+
+	const updateRange = (nextMinValue: string, nextMaxValue: string) => {
+		const nextMin = clampEpochSeconds(toEpochSeconds(nextMinValue));
+		let nextMax = clampEpochSeconds(toEpochSeconds(nextMaxValue));
+
+		if (nextMin !== undefined && nextMax !== undefined && nextMax < nextMin) {
+			nextMax = nextMin;
+		}
+
+		const nextRange = `${nextMin ?? ""}:${nextMax ?? ""}`;
+
+		if (archiveConfig?.splitByMonth && nextMin !== undefined) {
+			const clampedRange = clampTranscriptSearchRangeToMonth(nextRange);
+			if (clampedRange) {
+				const [clampedMin, clampedMax] = clampedRange.split(":", 2);
+				const clampedMinValue = clampEpochSeconds(
+					Number.parseInt(clampedMin || "", 10),
+				);
+				let clampedMaxValue = clampEpochSeconds(
+					Number.parseInt(clampedMax || "", 10),
+				);
+				if (
+					clampedMinValue !== undefined &&
+					clampedMaxValue !== undefined &&
+					clampedMaxValue < clampedMinValue
+				) {
+					clampedMaxValue = clampedMinValue;
+				}
+				refine([
+					Number.isFinite(clampedMinValue) ? clampedMinValue : undefined,
+					Number.isFinite(clampedMaxValue) ? clampedMaxValue : undefined,
+				]);
+			}
+			return;
+		}
+
+		refine([nextMin, nextMax]);
+	};
+
+	return (
+		<Row>
+			<Col>
+				{normalizedArchiveDepthDays !== null ? (
+					<div className="text-muted small mb-2">
+						Archive limited to the last {normalizedArchiveDepthDays} days.
+					</div>
+				) : null}
+				<label htmlFor="minStartTime">From Time</label>
+				<div className="input-group date">
+					<input
+						type="datetime-local"
+						id="minStartTime"
+						className="form-control"
+						value={minValue}
+						min={minAllowedInputValue || undefined}
+						onChange={(event) => {
+							const nextValue = event.target.value;
+							setMinValue(nextValue);
+							updateRange(nextValue, maxValue);
+						}}
+					/>
+					<span className="input-group-text">
+						<FaCalendar />
+					</span>
+				</div>
+			</Col>
+			<Col>
+				<label htmlFor="maxStartTime">To Time</label>
+				<div className="input-group date">
+					<input
+						type="datetime-local"
+						id="maxStartTime"
+						className="form-control"
+						value={maxValue}
+						min={minAllowedInputValue || undefined}
+						onChange={(event) => {
+							const nextValue = event.target.value;
+							setMaxValue(nextValue);
+							updateRange(minValue, nextValue);
+						}}
+					/>
+					<span className="input-group-text">
+						<FaCalendar />
+					</span>
+				</div>
+			</Col>
+		</Row>
+	);
 }

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -22,9 +22,7 @@ import {
 	useInstantSearch,
 	useRefinementList,
 } from "react-instantsearch";
-import {
-	extractScannerSearchScope,
-} from "@/lib/searchState";
+import { extractScannerSearchScope } from "@/lib/searchState";
 import {
 	createTranscriptHitTransformer,
 	parseSelectedHitId,
@@ -42,8 +40,9 @@ import {
 	transformCurrentRefinements,
 	transformHierarchyMenuItems,
 	transformSystemRefinementItems,
-	} from "@/lib/transcriptSearchLabels";
+} from "@/lib/transcriptSearchLabels";
 import { useTranscriptSearchCredentials } from "@/hooks/useTranscriptSearchCredentials";
+import { useEntitlements } from "@/providers/entitlements";
 import CallTimeRangeFilter from "./CallTimeRangeFilter";
 import SearchAnalysisPanel from "./chat/SearchAnalysisPanel";
 import { Hit as HitComponent } from "./Hit";
@@ -134,19 +133,19 @@ function TranscriptArchiveIndexNotice({
 	baseIndexName: string;
 	indexName: string;
 	splitByMonth: boolean;
-	}) {
-		const { indexUiState } = useInstantSearch<UiState>();
-		const archiveIndexConfig: TranscriptSearchIndexConfig = useMemo(
-			() => ({
-				baseIndexName,
-				splitByMonth,
-			}),
-			[baseIndexName, splitByMonth],
-		);
-		const currentMonthIndexName = useMemo(
-			() => getTranscriptCurrentMonthIndexName(archiveIndexConfig),
-			[archiveIndexConfig],
-		);
+}) {
+	const { indexUiState } = useInstantSearch<UiState>();
+	const archiveIndexConfig: TranscriptSearchIndexConfig = useMemo(
+		() => ({
+			baseIndexName,
+			splitByMonth,
+		}),
+		[baseIndexName, splitByMonth],
+	);
+	const currentMonthIndexName = useMemo(
+		() => getTranscriptCurrentMonthIndexName(archiveIndexConfig),
+		[archiveIndexConfig],
+	);
 	const indexState = (indexUiState || {}) as Record<string, unknown>;
 	const searchScope = useMemo(
 		() => extractScannerSearchScope(indexState),
@@ -168,7 +167,10 @@ function TranscriptArchiveIndexNotice({
 	);
 	const searchRange = searchScope.range?.start_time;
 	const nextIndexName = searchRange
-		? getTranscriptSearchIndexNameForRange(searchScope.range, archiveIndexConfig)
+		? getTranscriptSearchIndexNameForRange(
+				searchScope.range,
+				archiveIndexConfig,
+			)
 		: undefined;
 	const shouldRedirect =
 		splitByMonth && Boolean(searchRange) && nextIndexName !== indexName;
@@ -254,6 +256,7 @@ function TranscriptSearchResults({
 	indexName: string;
 	selectedHitId?: string;
 }) {
+	const entitlements = useEntitlements();
 	const { indexUiState, results } = useInstantSearch<UiState>();
 	const indexState = (indexUiState || {}) as Record<string, unknown>;
 	const sortBy =
@@ -293,7 +296,13 @@ function TranscriptSearchResults({
 
 	return (
 		<>
-			<SearchAnalysisPanel indexName={indexName} />
+			{entitlements.canUseAssistant() ? (
+				<SearchAnalysisPanel indexName={indexName} />
+			) : (
+				<Alert variant="secondary" className="mb-3">
+					AI analysis is not available for this account.
+				</Alert>
+			)}
 			<CurrentRefinements transformItems={transformCurrentRefinementItems} />
 			<Stats />
 			<Hits hitComponent={HitWithSelection} transformItems={transformItems} />
@@ -376,69 +385,79 @@ function SearchToolbarActions({ indexName }: { indexName: string }) {
 	);
 }
 
-	const SearchComponent = () => {
-		const { credentials, error, isLoading } = useTranscriptSearchCredentials();
-		const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
-			if (!credentials) {
-				return null;
-			}
+const SearchComponent = () => {
+	const { credentials, error, isLoading } = useTranscriptSearchCredentials();
+	const entitlements = useEntitlements();
+	const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
+		if (!credentials) {
+			return null;
+		}
 
-			return {
-				baseIndexName: credentials.baseIndexName,
-				splitByMonth: credentials.splitByMonth,
-			};
-		}, [credentials]);
-		const searchClient = useMemo(() => {
-			if (!credentials) {
-				return null;
-			}
+		return {
+			baseIndexName: credentials.baseIndexName,
+			splitByMonth: credentials.splitByMonth,
+		};
+	}, [credentials]);
+	const searchClient = useMemo(() => {
+		if (!credentials) {
+			return null;
+		}
 
-			return instantMeiliSearch(credentials.hostUrl, credentials.apiKey).searchClient;
-		}, [credentials]);
-		const searchLocationSearch =
-			typeof window === "undefined" ? "" : window.location.search;
-		const indexName =
-			archiveIndexConfig === null
-				? ""
-				: getTranscriptSearchIndexNameFromLocation(
-						searchLocationSearch,
-						archiveIndexConfig,
-					);
+		return instantMeiliSearch(credentials.hostUrl, credentials.apiKey)
+			.searchClient;
+	}, [credentials]);
+	const searchLocationSearch =
+		typeof window === "undefined" ? "" : window.location.search;
+	const indexName =
+		archiveIndexConfig === null
+			? ""
+			: getTranscriptSearchIndexNameFromLocation(
+					searchLocationSearch,
+					archiveIndexConfig,
+				);
 
-		const [filtersOpen, setFiltersOpen] = useState(true);
-		const [selectedHitId, setSelectedHitId] = useState<string | undefined>(() =>
-			typeof window === "undefined"
+	const [filtersOpen, setFiltersOpen] = useState(true);
+	const [selectedHitId, setSelectedHitId] = useState<string | undefined>(() =>
+		typeof window === "undefined"
 			? undefined
 			: parseSelectedHitId(window.location.hash),
 	);
 
 	let timer: ReturnType<typeof setTimeout>;
-		const queryHook = (query: string, refine: (nextQuery: string) => void) => {
-			clearTimeout(timer);
-			timer = setTimeout(() => refine(query), 500);
-		};
+	const queryHook = (query: string, refine: (nextQuery: string) => void) => {
+		clearTimeout(timer);
+		timer = setTimeout(() => refine(query), 500);
+	};
 
-		if (isLoading) {
-			return (
-				<Alert variant="secondary" className="m-3">
-					Loading transcript search…
-				</Alert>
-			);
-		}
+	if (isLoading) {
+		return (
+			<Alert variant="secondary" className="m-3">
+				Loading transcript search…
+			</Alert>
+		);
+	}
 
-		if (!credentials || !archiveIndexConfig || !searchClient) {
-			return (
-				<Alert variant="danger" className="m-3">
-					Failed to load search credentials.
-					{error ? <div className="small mt-2">{error.message}</div> : null}
-				</Alert>
-			);
-		}
+	if (!credentials || !archiveIndexConfig || !searchClient) {
+		return (
+			<Alert variant="danger" className="m-3">
+				Failed to load search credentials.
+				{error ? <div className="small mt-2">{error.message}</div> : null}
+			</Alert>
+		);
+	}
 
-		const routing = {
-			router: history({
-				windowTitle: (routeState) => {
-					const indexState = routeState[indexName] || {};
+	if (!entitlements.canSearchTranscripts()) {
+		return (
+			<Alert variant="warning" className="m-3">
+				Transcript search is not available for this account.
+			</Alert>
+		);
+	}
+
+	const routing = {
+		router: history({
+			windowTitle: (routeState) => {
+				const indexState = routeState[indexName] || {};
 
 				if (!indexState.query) {
 					return "Search Scanner Transcripts";
@@ -447,17 +466,17 @@ function SearchToolbarActions({ indexName }: { indexName: string }) {
 				return `${indexState.query} - Search Scanner Transcripts`;
 			},
 			parseURL: ({ qsModule, location }): UiState => {
-					const routeState = qsModule.parse(location.search.slice(1), {
-						arrayLimit: 99,
-					}) as unknown as UiState;
+				const routeState = qsModule.parse(location.search.slice(1), {
+					arrayLimit: 99,
+				}) as unknown as UiState;
 
-					if (credentials.splitByMonth && Object.keys(routeState).length) {
-						return remapSearchStateIndex(
-							routeState,
-							credentials.baseIndexName,
-							indexName,
-						);
-					}
+				if (credentials.splitByMonth && Object.keys(routeState).length) {
+					return remapSearchStateIndex(
+						routeState,
+						credentials.baseIndexName,
+						indexName,
+					);
+				}
 
 				if (!Object.keys(routeState).length) {
 					const defaultSort = `${indexName}:start_time:desc`;
@@ -700,22 +719,25 @@ function SearchToolbarActions({ indexName }: { indexName: string }) {
 									</Accordion.Body>
 								</Accordion.Item>
 
-									<Accordion.Item eventKey="8">
-										<Accordion.Header>Call Time</Accordion.Header>
-										<Accordion.Body>
-										<CallTimeRangeFilter archiveConfig={archiveIndexConfig} />
-										</Accordion.Body>
-									</Accordion.Item>
+								<Accordion.Item eventKey="8">
+									<Accordion.Header>Call Time</Accordion.Header>
+									<Accordion.Body>
+										<CallTimeRangeFilter
+											archiveConfig={archiveIndexConfig}
+											archiveDepthDays={entitlements.archiveDepthDays()}
+										/>
+									</Accordion.Body>
+								</Accordion.Item>
 							</Accordion>
 						</div>
 					</Collapse>
 				</Col>
-					<Col className="search-panel__results">
-						<TranscriptArchiveIndexNotice
-							baseIndexName={credentials.baseIndexName}
-							indexName={indexName}
-							splitByMonth={credentials.splitByMonth}
-						/>
+				<Col className="search-panel__results">
+					<TranscriptArchiveIndexNotice
+						baseIndexName={credentials.baseIndexName}
+						indexName={indexName}
+						splitByMonth={credentials.splitByMonth}
+					/>
 					<TranscriptSearchResults
 						indexName={indexName}
 						selectedHitId={selectedHitId}

--- a/frontend/src/components/TranscriptMap.tsx
+++ b/frontend/src/components/TranscriptMap.tsx
@@ -1,473 +1,492 @@
-'use client'
+"use client";
 
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
-import type { UiState } from 'instantsearch.js'
-import { history } from 'instantsearch.js/es/lib/routers'
-import { simple } from 'instantsearch.js/es/lib/stateMappings'
-import L from 'leaflet'
-import 'leaflet/dist/leaflet.css'
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { Alert, Badge, Col, Row } from 'react-bootstrap'
+import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
+import type { UiState } from "instantsearch.js";
+import { history } from "instantsearch.js/es/lib/routers";
+import { simple } from "instantsearch.js/es/lib/stateMappings";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Alert, Badge, Col, Row } from "react-bootstrap";
 import {
-  ClearRefinements,
-  CurrentRefinements,
-  HitsPerPage,
-  InstantSearch,
-  Pagination,
-  RefinementList,
-  SearchBox,
-  SortBy,
-  Stats,
-  useInstantSearch,
-  useRefinementList,
-} from 'react-instantsearch'
+	ClearRefinements,
+	CurrentRefinements,
+	HitsPerPage,
+	InstantSearch,
+	Pagination,
+	RefinementList,
+	SearchBox,
+	SortBy,
+	Stats,
+	useInstantSearch,
+	useRefinementList,
+} from "react-instantsearch";
 
-import { extractTranscriptGeoPoint } from '@/lib/transcriptGeo'
-import { extractScannerSearchScope } from '@/lib/searchState'
+import { extractTranscriptGeoPoint } from "@/lib/transcriptGeo";
+import { extractScannerSearchScope } from "@/lib/searchState";
 import {
-  createTranscriptHitTransformer,
-  type TranscriptRenderedHit,
-} from '@/lib/transcriptHits'
+	createTranscriptHitTransformer,
+	type TranscriptRenderedHit,
+} from "@/lib/transcriptHits";
 import {
-  DEFAULT_TRANSCRIPT_MAP_CENTER,
-  DEFAULT_TRANSCRIPT_MAP_BOUNDING_BOX,
-  DEFAULT_TRANSCRIPT_MAP_ZOOM,
-  formatInsideBoundingBox,
-} from '@/lib/transcriptGeoSearch'
+	DEFAULT_TRANSCRIPT_MAP_CENTER,
+	DEFAULT_TRANSCRIPT_MAP_BOUNDING_BOX,
+	DEFAULT_TRANSCRIPT_MAP_ZOOM,
+	formatInsideBoundingBox,
+} from "@/lib/transcriptGeoSearch";
 import {
-  getTranscriptSearchIndexNameFromLocation,
-  type TranscriptSearchIndexConfig,
-} from '@/lib/transcriptSearchIndex'
+	getTranscriptSearchIndexNameFromLocation,
+	type TranscriptSearchIndexConfig,
+} from "@/lib/transcriptSearchIndex";
 import {
-  transformCurrentRefinements,
-  transformSystemRefinementItems,
-} from '@/lib/transcriptSearchLabels'
-import { useTranscriptSearchCredentials } from '@/hooks/useTranscriptSearchCredentials'
-import CallTimeRangeFilter from './CallTimeRangeFilter'
-import { Hit as HitComponent } from './Hit'
+	transformCurrentRefinements,
+	transformSystemRefinementItems,
+} from "@/lib/transcriptSearchLabels";
+import { useTranscriptSearchCredentials } from "@/hooks/useTranscriptSearchCredentials";
+import { useEntitlements } from "@/providers/entitlements";
+import CallTimeRangeFilter from "./CallTimeRangeFilter";
+import { Hit as HitComponent } from "./Hit";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function remapSearchStateIndex(
-  routeState: UiState,
-  fromIndexName: string,
-  toIndexName: string,
+	routeState: UiState,
+	fromIndexName: string,
+	toIndexName: string,
 ): UiState {
-  if (fromIndexName === toIndexName) {
-    return routeState
-  }
+	if (fromIndexName === toIndexName) {
+		return routeState;
+	}
 
-  const nextRouteState = { ...routeState } as Record<string, unknown>
-  const fromIndexState = nextRouteState[fromIndexName]
-  if (!isRecord(fromIndexState)) {
-    return routeState
-  }
+	const nextRouteState = { ...routeState } as Record<string, unknown>;
+	const fromIndexState = nextRouteState[fromIndexName];
+	if (!isRecord(fromIndexState)) {
+		return routeState;
+	}
 
-  const toIndexState = isRecord(nextRouteState[toIndexName])
-    ? (nextRouteState[toIndexName] as Record<string, unknown>)
-    : {}
+	const toIndexState = isRecord(nextRouteState[toIndexName])
+		? (nextRouteState[toIndexName] as Record<string, unknown>)
+		: {};
 
-  nextRouteState[toIndexName] = {
-    ...toIndexState,
-    ...fromIndexState,
-  }
-  delete nextRouteState[fromIndexName]
-  return nextRouteState as UiState
+	nextRouteState[toIndexName] = {
+		...toIndexState,
+		...fromIndexState,
+	};
+	delete nextRouteState[fromIndexName];
+	return nextRouteState as UiState;
 }
 
 function buildDefaultIndexUiState(indexName: string) {
-  return {
-    sortBy: `${indexName}:start_time:desc`,
-  }
+	return {
+		sortBy: `${indexName}:start_time:desc`,
+	};
 }
 
 function transformCurrentRefinementItems(
-  items: Parameters<typeof transformCurrentRefinements>[0],
+	items: Parameters<typeof transformCurrentRefinements>[0],
 ) {
-  return transformCurrentRefinements(items)
+	return transformCurrentRefinements(items);
 }
 
 function transformSystemRefinementListItems(
-  items: Parameters<typeof transformSystemRefinementItems>[0],
+	items: Parameters<typeof transformSystemRefinementItems>[0],
 ) {
-  return transformSystemRefinementItems(items)
+	return transformSystemRefinementItems(items);
 }
 
 function VirtualRefinementList({ attribute }: { attribute: string }) {
-  useRefinementList({
-    attribute,
-    operator: 'or',
-  })
+	useRefinementList({
+		attribute,
+		operator: "or",
+	});
 
-  return null
+	return null;
 }
 
 function TranscriptGeoMap({ hits }: { hits: TranscriptRenderedHit[] }) {
-  const elementRef = useRef<HTMLDivElement | null>(null)
-  const mapRef = useRef<L.Map | null>(null)
-  const markersRef = useRef<L.LayerGroup | null>(null)
-  const [boundingBox, setBoundingBox] = useState(
-    DEFAULT_TRANSCRIPT_MAP_BOUNDING_BOX,
-  )
+	const elementRef = useRef<HTMLDivElement | null>(null);
+	const mapRef = useRef<L.Map | null>(null);
+	const markersRef = useRef<L.LayerGroup | null>(null);
+	const [boundingBox, setBoundingBox] = useState(
+		DEFAULT_TRANSCRIPT_MAP_BOUNDING_BOX,
+	);
 
-  useEffect(() => {
-    if (!elementRef.current || mapRef.current) {
-      return undefined
-    }
+	useEffect(() => {
+		if (!elementRef.current || mapRef.current) {
+			return undefined;
+		}
 
-    const map = L.map(elementRef.current, {
-      scrollWheelZoom: false,
-    }).setView(
-      [DEFAULT_TRANSCRIPT_MAP_CENTER.lat, DEFAULT_TRANSCRIPT_MAP_CENTER.lng],
-      DEFAULT_TRANSCRIPT_MAP_ZOOM,
-    )
+		const map = L.map(elementRef.current, {
+			scrollWheelZoom: false,
+		}).setView(
+			[DEFAULT_TRANSCRIPT_MAP_CENTER.lat, DEFAULT_TRANSCRIPT_MAP_CENTER.lng],
+			DEFAULT_TRANSCRIPT_MAP_ZOOM,
+		);
 
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    }).addTo(map)
+		L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+			attribution:
+				'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+		}).addTo(map);
 
-    const updateBoundingBox = () => {
-      setBoundingBox(formatInsideBoundingBox(map.getBounds()))
-    }
+		const updateBoundingBox = () => {
+			setBoundingBox(formatInsideBoundingBox(map.getBounds()));
+		};
 
-    markersRef.current = L.layerGroup().addTo(map)
-    map.on('moveend zoomend', updateBoundingBox)
-    updateBoundingBox()
-    mapRef.current = map
+		markersRef.current = L.layerGroup().addTo(map);
+		map.on("moveend zoomend", updateBoundingBox);
+		updateBoundingBox();
+		mapRef.current = map;
 
-    return () => {
-      map.off('moveend zoomend', updateBoundingBox)
-      markersRef.current?.clearLayers()
-      map.remove()
-      mapRef.current = null
-      markersRef.current = null
-    }
-  }, [])
+		return () => {
+			map.off("moveend zoomend", updateBoundingBox);
+			markersRef.current?.clearLayers();
+			map.remove();
+			mapRef.current = null;
+			markersRef.current = null;
+		};
+	}, []);
 
-  useEffect(() => {
-    const map = mapRef.current
-    const markers = markersRef.current
-    if (!map || !markers) {
-      return
-    }
+	useEffect(() => {
+		const map = mapRef.current;
+		const markers = markersRef.current;
+		if (!map || !markers) {
+			return;
+		}
 
-    markers.clearLayers()
-    const geoHits = hits
-      .map((hit) => ({
-        hit,
-        point: extractTranscriptGeoPoint(hit as Record<string, unknown>),
-      }))
-      .filter(
-        (
-          entry,
-        ): entry is {
-          hit: TranscriptRenderedHit
-          point: NonNullable<ReturnType<typeof extractTranscriptGeoPoint>>
-        } => Boolean(entry.point),
-      )
+		markers.clearLayers();
+		const geoHits = hits
+			.map((hit) => ({
+				hit,
+				point: extractTranscriptGeoPoint(hit as Record<string, unknown>),
+			}))
+			.filter(
+				(
+					entry,
+				): entry is {
+					hit: TranscriptRenderedHit;
+					point: NonNullable<ReturnType<typeof extractTranscriptGeoPoint>>;
+				} => Boolean(entry.point),
+			);
 
-    if (geoHits.length === 0) {
-      map.setView(
-        [DEFAULT_TRANSCRIPT_MAP_CENTER.lat, DEFAULT_TRANSCRIPT_MAP_CENTER.lng],
-        DEFAULT_TRANSCRIPT_MAP_ZOOM,
-      )
-      return
-    }
+		if (geoHits.length === 0) {
+			map.setView(
+				[DEFAULT_TRANSCRIPT_MAP_CENTER.lat, DEFAULT_TRANSCRIPT_MAP_CENTER.lng],
+				DEFAULT_TRANSCRIPT_MAP_ZOOM,
+			);
+			return;
+		}
 
-    const bounds = L.latLngBounds([])
-    geoHits.forEach(({ hit, point }) => {
-      const marker = L.circleMarker([point.lat, point.lng], {
-        radius: 7,
-        color: '#0d6efd',
-        weight: 2,
-        fillColor: '#0d6efd',
-        fillOpacity: 0.7,
-      }).addTo(markers)
+		const bounds = L.latLngBounds([]);
+		geoHits.forEach(({ hit, point }) => {
+			const marker = L.circleMarker([point.lat, point.lng], {
+				radius: 7,
+				color: "#0d6efd",
+				weight: 2,
+				fillColor: "#0d6efd",
+				fillOpacity: 0.7,
+			}).addTo(markers);
 
-      const popup = document.createElement('div')
-      popup.className = 'transcript-map-popup'
-      const title = document.createElement('a')
-      title.href = hit.permalink
-      title.textContent = `${hit.talkgroup_description} (${hit.talkgroup_tag})`
-      title.className = 'fw-semibold text-decoration-none'
-      popup.appendChild(title)
+			const popup = document.createElement("div");
+			popup.className = "transcript-map-popup";
+			const title = document.createElement("a");
+			title.href = hit.permalink;
+			title.textContent = `${hit.talkgroup_description} (${hit.talkgroup_tag})`;
+			title.className = "fw-semibold text-decoration-none";
+			popup.appendChild(title);
 
-      if (point.address) {
-        const address = document.createElement('div')
-        address.className = 'small text-muted'
-        address.textContent = point.address
-        popup.appendChild(address)
-      }
+			if (point.address) {
+				const address = document.createElement("div");
+				address.className = "small text-muted";
+				address.textContent = point.address;
+				popup.appendChild(address);
+			}
 
-      const timestamp = document.createElement('div')
-      timestamp.className = 'small'
-      timestamp.textContent = hit.start_time_string
-      popup.appendChild(timestamp)
+			const timestamp = document.createElement("div");
+			timestamp.className = "small";
+			timestamp.textContent = hit.start_time_string;
+			popup.appendChild(timestamp);
 
-      marker.bindPopup(popup)
-      bounds.extend([point.lat, point.lng])
-    })
+			marker.bindPopup(popup);
+			bounds.extend([point.lat, point.lng]);
+		});
 
-    map.fitBounds(bounds, {
-      padding: [24, 24],
-      maxZoom: 14,
-    })
-  }, [hits])
+		map.fitBounds(bounds, {
+			padding: [24, 24],
+			maxZoom: 14,
+		});
+	}, [hits]);
 
-  return (
-    <>
-      <div
-        ref={elementRef}
-        className="transcript-map ais-GeoSearch-map rounded border bg-body-tertiary"
-        aria-label="Transcript map"
-      />
-      <div className="small text-muted mt-2">
-        Bounding box: <code>{boundingBox}</code>
-      </div>
-    </>
-  )
+	return (
+		<>
+			<div
+				ref={elementRef}
+				className="transcript-map ais-GeoSearch-map rounded border bg-body-tertiary"
+				aria-label="Transcript map"
+			/>
+			<div className="small text-muted mt-2">
+				Bounding box: <code>{boundingBox}</code>
+			</div>
+		</>
+	);
 }
 
 function TranscriptMapResults({ indexName }: { indexName: string }) {
-  const { indexUiState, results } = useInstantSearch<UiState>()
-  const indexState = (indexUiState || {}) as Record<string, unknown>
-  const sortBy =
-    typeof indexState.sortBy === 'string' && indexState.sortBy
-      ? indexState.sortBy
-      : `${indexName}:start_time:desc`
-  const hitsPerPage =
-    typeof indexState.hitsPerPage === 'number' &&
-    Number.isFinite(indexState.hitsPerPage)
-      ? indexState.hitsPerPage
-      : 30
+	const { indexUiState, results } = useInstantSearch<UiState>();
+	const indexState = (indexUiState || {}) as Record<string, unknown>;
+	const sortBy =
+		typeof indexState.sortBy === "string" && indexState.sortBy
+			? indexState.sortBy
+			: `${indexName}:start_time:desc`;
+	const hitsPerPage =
+		typeof indexState.hitsPerPage === "number" &&
+		Number.isFinite(indexState.hitsPerPage)
+			? indexState.hitsPerPage
+			: 30;
 
-  const transformItems = useMemo(
-    () =>
-      createTranscriptHitTransformer({
-        indexName,
-        hitsPerPage,
-        sortBy,
-      }),
-    [hitsPerPage, indexName, sortBy],
-  )
+	const transformItems = useMemo(
+		() =>
+			createTranscriptHitTransformer({
+				indexName,
+				hitsPerPage,
+				sortBy,
+			}),
+		[hitsPerPage, indexName, sortBy],
+	);
 
-  const hits = useMemo(
-    () =>
-      transformItems(
-        ((results?.hits || []) as TranscriptRenderedHit[]).map((hit) => ({
-          ...hit,
-        })),
-      ),
-    [results?.hits, transformItems],
-  )
+	const hits = useMemo(
+		() =>
+			transformItems(
+				((results?.hits || []) as TranscriptRenderedHit[]).map((hit) => ({
+					...hit,
+				})),
+			),
+		[results?.hits, transformItems],
+	);
 
-  const geoHits = useMemo(
-    () => hits.filter((hit) => extractTranscriptGeoPoint(hit as Record<string, unknown>)),
-    [hits],
-  )
+	const geoHits = useMemo(
+		() =>
+			hits.filter((hit) =>
+				extractTranscriptGeoPoint(hit as Record<string, unknown>),
+			),
+		[hits],
+	);
 
-  return (
-    <>
-      <Row className="mb-3">
-        <Col lg={7}>
-          <TranscriptGeoMap hits={hits} />
-        </Col>
-        <Col lg={5}>
-          <div className="d-flex align-items-center justify-content-between mb-2">
-            <div className="fw-semibold">Map Results</div>
-            <Badge bg="secondary">{geoHits.length} mapped</Badge>
-          </div>
-          <Stats />
-          <div className="mt-2">
-            {hits.map((hit) => (
-              <HitComponent key={hit.id} hit={hit} />
-            ))}
-          </div>
-          <Pagination className="mt-3" />
-        </Col>
-      </Row>
-    </>
-  )
+	return (
+		<>
+			<Row className="mb-3">
+				<Col lg={7}>
+					<TranscriptGeoMap hits={hits} />
+				</Col>
+				<Col lg={5}>
+					<div className="d-flex align-items-center justify-content-between mb-2">
+						<div className="fw-semibold">Map Results</div>
+						<Badge bg="secondary">{geoHits.length} mapped</Badge>
+					</div>
+					<Stats />
+					<div className="mt-2">
+						{hits.map((hit) => (
+							<HitComponent key={hit.id} hit={hit} />
+						))}
+					</div>
+					<Pagination className="mt-3" />
+				</Col>
+			</Row>
+		</>
+	);
 }
 
 export default function TranscriptMap() {
-  const { credentials, error, isLoading } = useTranscriptSearchCredentials()
-  const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
-    if (!credentials) {
-      return null
-    }
+	const { credentials, error, isLoading } = useTranscriptSearchCredentials();
+	const entitlements = useEntitlements();
+	const archiveIndexConfig = useMemo<TranscriptSearchIndexConfig | null>(() => {
+		if (!credentials) {
+			return null;
+		}
 
-    return {
-      baseIndexName: credentials.baseIndexName,
-      splitByMonth: credentials.splitByMonth,
-    }
-  }, [credentials])
-  const searchClient = useMemo(() => {
-    if (!credentials) {
-      return null
-    }
+		return {
+			baseIndexName: credentials.baseIndexName,
+			splitByMonth: credentials.splitByMonth,
+		};
+	}, [credentials]);
+	const searchClient = useMemo(() => {
+		if (!credentials) {
+			return null;
+		}
 
-    return instantMeiliSearch(credentials.hostUrl, credentials.apiKey).searchClient
-  }, [credentials])
-  const searchLocationSearch =
-    typeof window === 'undefined' ? '' : window.location.search
-  const indexName =
-    archiveIndexConfig === null
-      ? ''
-      : getTranscriptSearchIndexNameFromLocation(
-          searchLocationSearch,
-          archiveIndexConfig,
-        )
+		return instantMeiliSearch(credentials.hostUrl, credentials.apiKey)
+			.searchClient;
+	}, [credentials]);
+	const searchLocationSearch =
+		typeof window === "undefined" ? "" : window.location.search;
+	const indexName =
+		archiveIndexConfig === null
+			? ""
+			: getTranscriptSearchIndexNameFromLocation(
+					searchLocationSearch,
+					archiveIndexConfig,
+				);
 
-  if (isLoading) {
-    return (
-      <Alert variant="secondary" className="m-3">
-        Loading transcript map…
-      </Alert>
-    )
-  }
+	if (isLoading) {
+		return (
+			<Alert variant="secondary" className="m-3">
+				Loading transcript map…
+			</Alert>
+		);
+	}
 
-  if (!credentials || !archiveIndexConfig || !searchClient) {
-    return (
-      <Alert variant="danger" className="m-3">
-        Failed to load search credentials.
-        {error ? <div className="small mt-2">{error.message}</div> : null}
-      </Alert>
-    )
-  }
+	if (!credentials || !archiveIndexConfig || !searchClient) {
+		return (
+			<Alert variant="danger" className="m-3">
+				Failed to load search credentials.
+				{error ? <div className="small mt-2">{error.message}</div> : null}
+			</Alert>
+		);
+	}
 
-  const routing = {
-    router: history({
-      windowTitle: (routeState) => {
-        const indexState = routeState[indexName] || {}
+	if (!entitlements.canSearchTranscripts()) {
+		return (
+			<Alert variant="warning" className="m-3">
+				Transcript map is not available for this account.
+			</Alert>
+		);
+	}
 
-        if (!indexState.query) {
-          return 'Transcript Map'
-        }
+	const routing = {
+		router: history({
+			windowTitle: (routeState) => {
+				const indexState = routeState[indexName] || {};
 
-        return `${indexState.query} - Transcript Map`
-      },
-      parseURL: ({ qsModule, location }): UiState => {
-        const routeState = qsModule.parse(location.search.slice(1), {
-          arrayLimit: 99,
-        }) as unknown as UiState
+				if (!indexState.query) {
+					return "Transcript Map";
+				}
 
-        if (credentials.splitByMonth && Object.keys(routeState).length) {
-          return remapSearchStateIndex(
-            routeState,
-            credentials.baseIndexName,
-            indexName,
-          )
-        }
+				return `${indexState.query} - Transcript Map`;
+			},
+			parseURL: ({ qsModule, location }): UiState => {
+				const routeState = qsModule.parse(location.search.slice(1), {
+					arrayLimit: 99,
+				}) as unknown as UiState;
 
-        if (!Object.keys(routeState).length) {
-          return {
-            [indexName]: buildDefaultIndexUiState(indexName),
-          }
-        }
+				if (credentials.splitByMonth && Object.keys(routeState).length) {
+					return remapSearchStateIndex(
+						routeState,
+						credentials.baseIndexName,
+						indexName,
+					);
+				}
 
-        return routeState
-      },
-      cleanUrlOnDispose: false,
-    }),
-    stateMapping: simple(),
-  }
+				if (!Object.keys(routeState).length) {
+					return {
+						[indexName]: buildDefaultIndexUiState(indexName),
+					};
+				}
 
-  return (
-    <InstantSearch
-      key={indexName}
-      searchClient={searchClient}
-      indexName={indexName}
-      routing={routing}
-      future={{ preserveSharedStateOnUnmount: true }}
-    >
-      <VirtualRefinementList attribute="talkgroup_description" />
-      <h1>Transcript Map</h1>
-      <Row className="mb-2">
-        <Col lg={3} className="d-none d-lg-block">
-          <h2 className="fs-4">Filters</h2>
-        </Col>
-        <Col>
-          <Row>
-            <SearchBox
-              className="col-lg mb-2 mb-lg-0"
-              classNames={{ input: 'form-control' }}
-            />
-            <SortBy
-              className="col-lg-auto col"
-              items={[
-                {
-                  label: 'Newest First',
-                  value: `${indexName}:start_time:desc`,
-                },
-                { label: 'Oldest First', value: `${indexName}:start_time:asc` },
-                { label: 'Relevance', value: indexName },
-              ]}
-            />
-            <HitsPerPage
-              className="col-lg-auto col"
-              items={[
-                { label: '20 per page', value: 20, default: true },
-                { label: '40 per page', value: 40 },
-                { label: '60 per page', value: 60 },
-              ]}
-            />
-          </Row>
-        </Col>
-      </Row>
-      <Row>
-        <Col className="search-panel__filters" lg={3}>
-          <ClearRefinements
-            translations={{
-              resetButtonText: 'Clear Filters',
-            }}
-          />
-          <div className="mt-3">
-            <RefinementList
-              attribute="short_name"
-              operator="or"
-              showMore={true}
-              showMoreLimit={60}
-              searchable={true}
-              classNames={{
-                label: 'form-check-label',
-                checkbox: 'form-check-input',
-                item: 'form-check',
-                count: 'ms-1',
-              }}
-              transformItems={transformSystemRefinementListItems}
-            />
-          </div>
-          <div className="mt-3">
-            <RefinementList
-              attribute="talkgroup_group"
-              operator="or"
-              showMore={true}
-              showMoreLimit={60}
-              searchable={true}
-              classNames={{
-                label: 'form-check-label',
-                checkbox: 'form-check-input',
-                item: 'form-check',
-                count: 'ms-1',
-              }}
-            />
-          </div>
-          <div className="mt-3">
-            <CallTimeRangeFilter archiveConfig={archiveIndexConfig} />
-          </div>
-        </Col>
-        <Col className="search-panel__results">
-          <CurrentRefinements transformItems={transformCurrentRefinementItems} />
-          <Alert variant="info" className="mb-3">
-            The map only shows calls with coordinates in the indexed documents.
-          </Alert>
-          <TranscriptMapResults indexName={indexName} />
-        </Col>
-      </Row>
-    </InstantSearch>
-  )
+				return routeState;
+			},
+			cleanUrlOnDispose: false,
+		}),
+		stateMapping: simple(),
+	};
+
+	return (
+		<InstantSearch
+			key={indexName}
+			searchClient={searchClient}
+			indexName={indexName}
+			routing={routing}
+			future={{ preserveSharedStateOnUnmount: true }}
+		>
+			<VirtualRefinementList attribute="talkgroup_description" />
+			<h1>Transcript Map</h1>
+			<Row className="mb-2">
+				<Col lg={3} className="d-none d-lg-block">
+					<h2 className="fs-4">Filters</h2>
+				</Col>
+				<Col>
+					<Row>
+						<SearchBox
+							className="col-lg mb-2 mb-lg-0"
+							classNames={{ input: "form-control" }}
+						/>
+						<SortBy
+							className="col-lg-auto col"
+							items={[
+								{
+									label: "Newest First",
+									value: `${indexName}:start_time:desc`,
+								},
+								{ label: "Oldest First", value: `${indexName}:start_time:asc` },
+								{ label: "Relevance", value: indexName },
+							]}
+						/>
+						<HitsPerPage
+							className="col-lg-auto col"
+							items={[
+								{ label: "20 per page", value: 20, default: true },
+								{ label: "40 per page", value: 40 },
+								{ label: "60 per page", value: 60 },
+							]}
+						/>
+					</Row>
+				</Col>
+			</Row>
+			<Row>
+				<Col className="search-panel__filters" lg={3}>
+					<ClearRefinements
+						translations={{
+							resetButtonText: "Clear Filters",
+						}}
+					/>
+					<div className="mt-3">
+						<RefinementList
+							attribute="short_name"
+							operator="or"
+							showMore={true}
+							showMoreLimit={60}
+							searchable={true}
+							classNames={{
+								label: "form-check-label",
+								checkbox: "form-check-input",
+								item: "form-check",
+								count: "ms-1",
+							}}
+							transformItems={transformSystemRefinementListItems}
+						/>
+					</div>
+					<div className="mt-3">
+						<RefinementList
+							attribute="talkgroup_group"
+							operator="or"
+							showMore={true}
+							showMoreLimit={60}
+							searchable={true}
+							classNames={{
+								label: "form-check-label",
+								checkbox: "form-check-input",
+								item: "form-check",
+								count: "ms-1",
+							}}
+						/>
+					</div>
+					<div className="mt-3">
+						<CallTimeRangeFilter
+							archiveConfig={archiveIndexConfig}
+							archiveDepthDays={entitlements.archiveDepthDays()}
+						/>
+					</div>
+				</Col>
+				<Col className="search-panel__results">
+					<CurrentRefinements
+						transformItems={transformCurrentRefinementItems}
+					/>
+					<Alert variant="info" className="mb-3">
+						The map only shows calls with coordinates in the indexed documents.
+					</Alert>
+					<TranscriptMapResults indexName={indexName} />
+				</Col>
+			</Row>
+		</InstantSearch>
+	);
 }

--- a/frontend/src/providers/entitlements.tsx
+++ b/frontend/src/providers/entitlements.tsx
@@ -3,11 +3,17 @@ import { createContext, useContext, type ReactNode } from "react";
 export type EntitlementsService = {
 	canSearchTranscripts: () => boolean;
 	canCreateAlerts: () => boolean;
+	canUseAssistant: () => boolean;
+	archiveDepthDays: () => number | null;
+	canExportAudio: () => boolean;
 };
 
 const defaultEntitlementsService: EntitlementsService = {
 	canSearchTranscripts: () => true,
 	canCreateAlerts: () => false,
+	canUseAssistant: () => true,
+	archiveDepthDays: () => null,
+	canExportAudio: () => false,
 };
 
 const EntitlementsContext = createContext<EntitlementsService>(
@@ -22,9 +28,7 @@ export function EntitlementsProvider({
 	service?: EntitlementsService;
 }) {
 	return (
-		<EntitlementsContext.Provider
-			value={service ?? defaultEntitlementsService}
-		>
+		<EntitlementsContext.Provider value={service ?? defaultEntitlementsService}>
 			{children}
 		</EntitlementsContext.Provider>
 	);
@@ -33,4 +37,3 @@ export function EntitlementsProvider({
 export function useEntitlements(): EntitlementsService {
 	return useContext(EntitlementsContext);
 }
-


### PR DESCRIPTION
Implements `CRI-65` groundwork by expanding the entitlements/capabilities contract to include:
- `canSearchTranscripts`
- `canCreateAlerts`
- `canUseAssistant`
- `archiveDepthDays`
- `canExportAudio`

Also adds capability-based gating in the transcript Search/Map flows:
- hides AI Analysis panel when `canUseAssistant` is false
- blocks Search/Map UI when `canSearchTranscripts` is false
- clamps the Call Time filter to `archiveDepthDays` (and sets input `min`), while preserving the existing monthly-index clamping behavior.

Local verification: `cd frontend && npm test`.