### PR TITLE
Frontend: Sirens backend adapter for saved searches (CRI-64)

### DIFF
--- a/frontend/src/components/SavedTranscriptSearches.tsx
+++ b/frontend/src/components/SavedTranscriptSearches.tsx
@@ -1,238 +1,265 @@
-'use client'
+"use client";
 
-import type { UiState } from 'instantsearch.js'
-import { useEffect, useMemo, useState } from 'react'
-import { Badge, Button, ListGroup } from 'react-bootstrap'
-import { useInstantSearch } from 'react-instantsearch'
+import type { UiState } from "instantsearch.js";
+import { useEffect, useMemo, useState } from "react";
+import { Badge, Button, ListGroup } from "react-bootstrap";
+import { useInstantSearch } from "react-instantsearch";
 
 import {
-  buildTranscriptSavedSearchUrl,
-  deleteTranscriptSavedSearchEntry,
-  describeTranscriptSavedSearchState,
-  extractTranscriptSavedSearchState,
-  upsertTranscriptSavedSearchEntry,
-  type TranscriptSavedSearchEntry,
-} from '@/lib/transcriptSavedSearches'
-import { useSavedSearchStore } from '@/providers/savedSearchStore'
+	buildTranscriptSavedSearchUrl,
+	deleteTranscriptSavedSearchEntry,
+	describeTranscriptSavedSearchState,
+	extractTranscriptSavedSearchState,
+	upsertTranscriptSavedSearchEntry,
+	type TranscriptSavedSearchEntry,
+} from "@/lib/transcriptSavedSearches";
+import { useSavedSearchStore } from "@/providers/savedSearchStore";
 
 function formatSavedSearchTimestamp(timestamp: string): string {
-  const parsed = new Date(timestamp)
-  return Number.isNaN(parsed.getTime()) ? timestamp : parsed.toLocaleString()
+	const parsed = new Date(timestamp);
+	return Number.isNaN(parsed.getTime()) ? timestamp : parsed.toLocaleString();
 }
 
 export default function SavedTranscriptSearches({
-  indexName,
+	indexName,
 }: {
-  indexName: string
+	indexName: string;
 }) {
-  const { indexUiState, setUiState } = useInstantSearch<UiState>()
-  const savedSearchStore = useSavedSearchStore()
-  const [savedSearches, setSavedSearches] = useState<TranscriptSavedSearchEntry[]>(
-    [],
-  )
+	const { indexUiState, setUiState } = useInstantSearch<UiState>();
+	const savedSearchStore = useSavedSearchStore();
+	const [savedSearches, setSavedSearches] = useState<
+		TranscriptSavedSearchEntry[]
+	>([]);
 
-  useEffect(() => {
-    let isActive = true
-    savedSearchStore
-      .list()
-      .then((entries) => {
-        if (isActive) {
-          setSavedSearches(entries)
-        }
-      })
-      .catch((error) => {
-        console.error('Failed to load saved searches', error)
-      })
+	useEffect(() => {
+		let isActive = true;
+		savedSearchStore
+			.list()
+			.then((entries) => {
+				if (isActive) {
+					setSavedSearches(entries);
+				}
+			})
+			.catch((error) => {
+				console.error("Failed to load saved searches", error);
+			});
 
-    return () => {
-      isActive = false
-    }
-  }, [savedSearchStore])
+		return () => {
+			isActive = false;
+		};
+	}, [savedSearchStore]);
 
-  const currentState = useMemo(
-    () =>
-      extractTranscriptSavedSearchState(
-        (indexUiState || {}) as Record<string, unknown>,
-      ),
-    [indexUiState],
-  )
+	const currentState = useMemo(
+		() =>
+			extractTranscriptSavedSearchState(
+				(indexUiState || {}) as Record<string, unknown>,
+			),
+		[indexUiState],
+	);
 
-  const currentStateSignature = useMemo(
-    () => JSON.stringify(currentState),
-    [currentState],
-  )
+	const currentStateSignature = useMemo(
+		() => JSON.stringify(currentState),
+		[currentState],
+	);
 
-  const saveCurrentSearch = async () => {
-    if (typeof window === 'undefined') {
-      return
-    }
+	const saveCurrentSearch = async () => {
+		if (typeof window === "undefined") {
+			return;
+		}
 
-    const defaultName = currentState.query || 'Untitled search'
-    const name = window.prompt('Enter a name for this saved search', defaultName)
-    if (!name || !name.trim()) {
-      return
-    }
+		const defaultName = currentState.query || "Untitled search";
+		const name = window.prompt(
+			"Enter a name for this saved search",
+			defaultName,
+		);
+		if (!name || !name.trim()) {
+			return;
+		}
 
-    try {
-      const created = await savedSearchStore.create(name, currentState)
-      setSavedSearches((currentEntries) =>
-        upsertTranscriptSavedSearchEntry(currentEntries, created),
-      )
-    } catch (error) {
-      console.error('Failed to create saved search', error)
-    }
-  }
+		try {
+			const created = await savedSearchStore.create(
+				name,
+				currentState,
+				indexName,
+			);
+			setSavedSearches((currentEntries) =>
+				upsertTranscriptSavedSearchEntry(currentEntries, created),
+			);
+		} catch (error) {
+			console.error("Failed to create saved search", error);
+		}
+	};
 
-  const openSavedSearch = (entry: TranscriptSavedSearchEntry) => {
-    setUiState((currentUiState) => ({
-      ...currentUiState,
-      [indexName]: {
-        ...entry.state,
-      },
-    }))
-  }
+	const openSavedSearch = (entry: TranscriptSavedSearchEntry) => {
+		setUiState((currentUiState) => ({
+			...currentUiState,
+			[indexName]: {
+				...entry.state,
+			},
+		}));
+	};
 
-  const updateSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
-    const shouldUpdate =
-      typeof window === 'undefined'
-        ? true
-        : window.confirm(`Update "${entry.name}" with the current search state?`)
+	const updateSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
+		const shouldUpdate =
+			typeof window === "undefined"
+				? true
+				: window.confirm(
+						`Update "${entry.name}" with the current search state?`,
+					);
 
-    if (!shouldUpdate) {
-      return
-    }
+		if (!shouldUpdate) {
+			return;
+		}
 
-    try {
-      const updated = await savedSearchStore.update(entry.id, currentState)
-      setSavedSearches((currentEntries) =>
-        upsertTranscriptSavedSearchEntry(currentEntries, updated),
-      )
-    } catch (error) {
-      console.error('Failed to update saved search', error)
-    }
-  }
+		try {
+			const updated = await savedSearchStore.update(
+				entry.id,
+				currentState,
+				indexName,
+			);
+			setSavedSearches((currentEntries) =>
+				upsertTranscriptSavedSearchEntry(currentEntries, updated),
+			);
+		} catch (error) {
+			console.error("Failed to update saved search", error);
+		}
+	};
 
-  const removeSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
-    const shouldDelete =
-      typeof window === 'undefined'
-        ? true
-        : window.confirm(`Delete saved search "${entry.name}"?`)
+	const removeSavedSearch = async (entry: TranscriptSavedSearchEntry) => {
+		const shouldDelete =
+			typeof window === "undefined"
+				? true
+				: window.confirm(`Delete saved search "${entry.name}"?`);
 
-    if (!shouldDelete) {
-      return
-    }
+		if (!shouldDelete) {
+			return;
+		}
 
-    try {
-      await savedSearchStore.remove(entry.id)
-      setSavedSearches((currentEntries) =>
-        deleteTranscriptSavedSearchEntry(currentEntries, entry.id),
-      )
-    } catch (error) {
-      console.error('Failed to remove saved search', error)
-    }
-  }
+		try {
+			await savedSearchStore.remove(entry.id);
+			setSavedSearches((currentEntries) =>
+				deleteTranscriptSavedSearchEntry(currentEntries, entry.id),
+			);
+		} catch (error) {
+			console.error("Failed to remove saved search", error);
+		}
+	};
 
-  return (
-    <div className="saved-searches-panel">
-      <div className="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
-        <div>
-          <div className="fw-semibold">Saved Searches</div>
-          <div className="text-muted small">
-            Save and reopen the current transcript search state from this browser.
-          </div>
-        </div>
-        <Button type="button" size="sm" variant="outline-primary" onClick={saveCurrentSearch}>
-          Save current search
-        </Button>
-      </div>
+	return (
+		<div className="saved-searches-panel">
+			<div className="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+				<div>
+					<div className="fw-semibold">Saved Searches</div>
+					<div className="text-muted small">
+						Save and reopen the current transcript search state from this
+						browser.
+					</div>
+				</div>
+				<Button
+					type="button"
+					size="sm"
+					variant="outline-primary"
+					onClick={saveCurrentSearch}
+				>
+					Save current search
+				</Button>
+			</div>
 
-      {savedSearches.length === 0 ? (
-        <div className="text-muted small">No saved searches yet.</div>
-      ) : (
-        <ListGroup className="saved-searches-list">
-          {savedSearches.map((entry) => {
-            const summary = describeTranscriptSavedSearchState(entry.state)
-            const isActive = JSON.stringify(entry.state) === currentStateSignature
-            const openUrl = buildTranscriptSavedSearchUrl(indexName, entry.state)
+			{savedSearches.length === 0 ? (
+				<div className="text-muted small">No saved searches yet.</div>
+			) : (
+				<ListGroup className="saved-searches-list">
+					{savedSearches.map((entry) => {
+						const summary = describeTranscriptSavedSearchState(entry.state);
+						const isActive =
+							JSON.stringify(entry.state) === currentStateSignature;
+						const openUrl = buildTranscriptSavedSearchUrl(
+							indexName,
+							entry.state,
+						);
 
-            return (
-              <ListGroup.Item
-                key={entry.id}
-                className="d-flex flex-column gap-2"
-                active={isActive}
-              >
-                <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                  <div>
-                    <a
-                      href={openUrl}
-                      className={`fw-semibold text-decoration-none ${
-                        isActive ? 'text-white' : 'text-body'
-                      }`}
-                      onClick={(event) => {
-                        event.preventDefault()
-                        openSavedSearch(entry)
-                      }}
-                    >
-                      {entry.name}
-                    </a>
-                    <div className={`small ${isActive ? 'text-white-50' : 'text-muted'}`}>
-                      Updated {formatSavedSearchTimestamp(entry.updatedAt)}
-                    </div>
-                  </div>
+						return (
+							<ListGroup.Item
+								key={entry.id}
+								className="d-flex flex-column gap-2"
+								active={isActive}
+							>
+								<div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
+									<div>
+										<a
+											href={openUrl}
+											className={`fw-semibold text-decoration-none ${
+												isActive ? "text-white" : "text-body"
+											}`}
+											onClick={(event) => {
+												event.preventDefault();
+												openSavedSearch(entry);
+											}}
+										>
+											{entry.name}
+										</a>
+										<div
+											className={`small ${isActive ? "text-white-50" : "text-muted"}`}
+										>
+											Updated {formatSavedSearchTimestamp(entry.updatedAt)}
+										</div>
+									</div>
 
-                  <div className="d-flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant={isActive ? 'light' : 'outline-primary'}
-                      onClick={() => {
-                        openSavedSearch(entry)
-                      }}
-                    >
-                      Open
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant={isActive ? 'light' : 'outline-secondary'}
-                      onClick={() => {
-                        updateSavedSearch(entry)
-                      }}
-                    >
-                      Update
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant={isActive ? 'light' : 'outline-danger'}
-                      onClick={() => {
-                        removeSavedSearch(entry)
-                      }}
-                    >
-                      Delete
-                    </Button>
-                  </div>
-                </div>
+									<div className="d-flex flex-wrap gap-2">
+										<Button
+											type="button"
+											size="sm"
+											variant={isActive ? "light" : "outline-primary"}
+											onClick={() => {
+												openSavedSearch(entry);
+											}}
+										>
+											Open
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant={isActive ? "light" : "outline-secondary"}
+											onClick={() => {
+												updateSavedSearch(entry);
+											}}
+										>
+											Update
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant={isActive ? "light" : "outline-danger"}
+											onClick={() => {
+												removeSavedSearch(entry);
+											}}
+										>
+											Delete
+										</Button>
+									</div>
+								</div>
 
-                {summary.length > 0 ? (
-                  <div className={`small ${isActive ? 'text-white-50' : 'text-muted'}`}>
-                    {summary.map((item) => (
-                      <Badge
-                        bg={isActive ? 'light' : 'secondary'}
-                        text={isActive ? 'dark' : 'light'}
-                        className="me-1 mb-1"
-                        key={item}
-                      >
-                        {item}
-                      </Badge>
-                    ))}
-                  </div>
-                ) : null}
-              </ListGroup.Item>
-            )
-          })}
-        </ListGroup>
-      )}
-    </div>
-  )
+								{summary.length > 0 ? (
+									<div
+										className={`small ${isActive ? "text-white-50" : "text-muted"}`}
+									>
+										{summary.map((item) => (
+											<Badge
+												bg={isActive ? "light" : "secondary"}
+												text={isActive ? "dark" : "light"}
+												className="me-1 mb-1"
+												key={item}
+											>
+												{item}
+											</Badge>
+										))}
+									</div>
+								) : null}
+							</ListGroup.Item>
+						);
+					})}
+				</ListGroup>
+			)}
+		</div>
+	);
 }

--- a/frontend/src/lib/searchState.test.ts
+++ b/frontend/src/lib/searchState.test.ts
@@ -1,144 +1,184 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from "vitest";
 
 import {
-  DEFAULT_MAX_ANALYSIS_HITS,
-  buildScannerSearchUrl,
-  createScannerChatThreadId,
-  extractScannerSearchScope,
-  extractScannerSearchUiState,
-} from './searchState'
+	DEFAULT_MAX_ANALYSIS_HITS,
+	buildScannerSearchUrl,
+	createScannerChatThreadId,
+	extractScannerSearchScope,
+	extractScannerSearchUiState,
+	parseScannerSearchUrl,
+} from "./searchState";
 
-describe('searchState', () => {
-  it('extracts a normalized scanner search scope from instantsearch ui state', () => {
-    expect(
-      extractScannerSearchScope({
-        query: '  shots fired ',
-        refinementList: {
-          short_name: ['sys2', 'sys1', 'sys1'],
-          talkgroup_tag: ['Zone 10'],
-          ignored: ['value'],
-        },
-        hierarchicalMenu: {
-          'talkgroup_hierarchy.lvl1': 'sys1 > Police',
-          ignored: 'value',
-        },
-        range: {
-          start_time: '1700000000:1700003600',
-        },
-        page: 4,
-        hitsPerPage: 60,
-        sortBy: 'calls:start_time:asc',
-      }),
-    ).toEqual({
-      query: 'shots fired',
-      refinementList: {
-        short_name: ['sys1', 'sys2'],
-        talkgroup_tag: ['Zone 10'],
-      },
-      hierarchicalMenu: {
-        'talkgroup_hierarchy.lvl1': 'sys1 > Police',
-      },
-      range: {
-        start_time: '1700000000:1700003600',
-      },
-      maxHits: DEFAULT_MAX_ANALYSIS_HITS,
-    })
-  })
+describe("searchState", () => {
+	it("extracts a normalized scanner search scope from instantsearch ui state", () => {
+		expect(
+			extractScannerSearchScope({
+				query: "  shots fired ",
+				refinementList: {
+					short_name: ["sys2", "sys1", "sys1"],
+					talkgroup_tag: ["Zone 10"],
+					ignored: ["value"],
+				},
+				hierarchicalMenu: {
+					"talkgroup_hierarchy.lvl1": "sys1 > Police",
+					ignored: "value",
+				},
+				range: {
+					start_time: "1700000000:1700003600",
+				},
+				page: 4,
+				hitsPerPage: 60,
+				sortBy: "calls:start_time:asc",
+			}),
+		).toEqual({
+			query: "shots fired",
+			refinementList: {
+				short_name: ["sys1", "sys2"],
+				talkgroup_tag: ["Zone 10"],
+			},
+			hierarchicalMenu: {
+				"talkgroup_hierarchy.lvl1": "sys1 > Police",
+			},
+			range: {
+				start_time: "1700000000:1700003600",
+			},
+			maxHits: DEFAULT_MAX_ANALYSIS_HITS,
+		});
+	});
 
-  it('builds scanner search urls with full scope, range, and hit anchors', () => {
-    const relativeUrl = buildScannerSearchUrl({
-      scope: {
-        query: 'shots fired',
-        refinementList: {
-          talkgroup_description: ['Main Dispatch'],
-          short_name: ['sys1'],
-        },
-        hierarchicalMenu: {
-          'talkgroup_hierarchy.lvl2': 'sys1 > Police > Main Dispatch',
-        },
-        range: {
-          start_time: '1741500000:1741507200',
-        },
-      },
-      callId: 'abc123',
-      hitsPerPage: 40,
-      sortBy: 'calls:start_time:asc',
-    })
+	it("builds scanner search urls with full scope, range, and hit anchors", () => {
+		const relativeUrl = buildScannerSearchUrl({
+			scope: {
+				query: "shots fired",
+				refinementList: {
+					talkgroup_description: ["Main Dispatch"],
+					short_name: ["sys1"],
+				},
+				hierarchicalMenu: {
+					"talkgroup_hierarchy.lvl2": "sys1 > Police > Main Dispatch",
+				},
+				range: {
+					start_time: "1741500000:1741507200",
+				},
+			},
+			callId: "abc123",
+			hitsPerPage: 40,
+			sortBy: "calls:start_time:asc",
+		});
 
-    const url = new URL(relativeUrl, 'http://localhost')
-    expect(url.pathname).toBe('/')
-    expect(url.hash).toBe('#hit-abc123')
-    expect(url.searchParams.get('calls[query]')).toBe('shots fired')
-    expect(url.searchParams.get('calls[refinementList][talkgroup_description][0]')).toBe(
-      'Main Dispatch',
-    )
-    expect(url.searchParams.get('calls[refinementList][short_name][0]')).toBe('sys1')
-    expect(url.searchParams.get('calls[hierarchicalMenu][talkgroup_hierarchy.lvl2]')).toBe(
-      'sys1 > Police > Main Dispatch',
-    )
-    expect(url.searchParams.get('calls[range][start_time]')).toBe(
-      '1741500000:1741507200',
-    )
-    expect(url.searchParams.get('calls[hitsPerPage]')).toBe('40')
-    expect(url.searchParams.get('calls[sortBy]')).toBe('calls:start_time:asc')
-  })
+		const url = new URL(relativeUrl, "http://localhost");
+		expect(url.pathname).toBe("/");
+		expect(url.hash).toBe("#hit-abc123");
+		expect(url.searchParams.get("calls[query]")).toBe("shots fired");
+		expect(
+			url.searchParams.get("calls[refinementList][talkgroup_description][0]"),
+		).toBe("Main Dispatch");
+		expect(url.searchParams.get("calls[refinementList][short_name][0]")).toBe(
+			"sys1",
+		);
+		expect(
+			url.searchParams.get("calls[hierarchicalMenu][talkgroup_hierarchy.lvl2]"),
+		).toBe("sys1 > Police > Main Dispatch");
+		expect(url.searchParams.get("calls[range][start_time]")).toBe(
+			"1741500000:1741507200",
+		);
+		expect(url.searchParams.get("calls[hitsPerPage]")).toBe("40");
+		expect(url.searchParams.get("calls[sortBy]")).toBe("calls:start_time:asc");
+	});
 
-  it('creates stable thread ids from the normalized search scope', () => {
-    const baseScope = {
-      query: 'shots fired',
-      refinementList: {
-        short_name: ['sys1', 'sys2'],
-      },
-      range: {
-        start_time: '1741500000:1741507200',
-      },
-    }
+	it("creates stable thread ids from the normalized search scope", () => {
+		const baseScope = {
+			query: "shots fired",
+			refinementList: {
+				short_name: ["sys1", "sys2"],
+			},
+			range: {
+				start_time: "1741500000:1741507200",
+			},
+		};
 
-    expect(createScannerChatThreadId(baseScope)).toBe(
-      createScannerChatThreadId({
-        ...baseScope,
-        refinementList: {
-          short_name: ['sys2', 'sys1'],
-        },
-      }),
-    )
-    expect(
-      createScannerChatThreadId({
-        ...baseScope,
-        query: 'vehicle pursuit',
-      }),
-    ).not.toBe(createScannerChatThreadId(baseScope))
-  })
+		expect(createScannerChatThreadId(baseScope)).toBe(
+			createScannerChatThreadId({
+				...baseScope,
+				refinementList: {
+					short_name: ["sys2", "sys1"],
+				},
+			}),
+		);
+		expect(
+			createScannerChatThreadId({
+				...baseScope,
+				query: "vehicle pursuit",
+			}),
+		).not.toBe(createScannerChatThreadId(baseScope));
+	});
 
-  it('extracts a normalized scanner search ui state without the analysis limit', () => {
-    expect(
-      extractScannerSearchUiState({
-        query: ' shots fired ',
-        refinementList: {
-          short_name: ['sys2', 'sys1'],
-        },
-        hierarchicalMenu: {
-          'talkgroup_hierarchy.lvl0': 'sys1',
-        },
-        range: {
-          start_time: '1700000000:1700003600',
-        },
-        sortBy: ' calls:start_time:asc ',
-        hitsPerPage: 40,
-      }),
-    ).toEqual({
-      query: 'shots fired',
-      refinementList: {
-        short_name: ['sys1', 'sys2'],
-      },
-      hierarchicalMenu: {
-        'talkgroup_hierarchy.lvl0': 'sys1',
-      },
-      range: {
-        start_time: '1700000000:1700003600',
-      },
-      sortBy: 'calls:start_time:asc',
-      hitsPerPage: 40,
-    })
-  })
-})
+	it("extracts a normalized scanner search ui state without the analysis limit", () => {
+		expect(
+			extractScannerSearchUiState({
+				query: " shots fired ",
+				refinementList: {
+					short_name: ["sys2", "sys1"],
+				},
+				hierarchicalMenu: {
+					"talkgroup_hierarchy.lvl0": "sys1",
+				},
+				range: {
+					start_time: "1700000000:1700003600",
+				},
+				sortBy: " calls:start_time:asc ",
+				hitsPerPage: 40,
+			}),
+		).toEqual({
+			query: "shots fired",
+			refinementList: {
+				short_name: ["sys1", "sys2"],
+			},
+			hierarchicalMenu: {
+				"talkgroup_hierarchy.lvl0": "sys1",
+			},
+			range: {
+				start_time: "1700000000:1700003600",
+			},
+			sortBy: "calls:start_time:asc",
+			hitsPerPage: 40,
+		});
+	});
+
+	it("parses scanner search urls back into normalized ui state", () => {
+		const builtUrl = buildScannerSearchUrl({
+			indexName: "calls_2026_04",
+			scope: {
+				query: "shots fired",
+				refinementList: {
+					short_name: ["sys1", "sys2"],
+				},
+				hierarchicalMenu: {
+					"talkgroup_hierarchy.lvl2": "sys1 > Police > Main Dispatch",
+				},
+				range: {
+					start_time: "1741500000:1741507200",
+				},
+			},
+			hitsPerPage: 40,
+			sortBy: "calls_2026_04:start_time:asc",
+		});
+
+		const parsed = parseScannerSearchUrl(builtUrl);
+		expect(parsed?.indexName).toBe("calls_2026_04");
+		expect(parsed?.state).toEqual({
+			query: "shots fired",
+			refinementList: {
+				short_name: ["sys1", "sys2"],
+			},
+			hierarchicalMenu: {
+				"talkgroup_hierarchy.lvl2": "sys1 > Police > Main Dispatch",
+			},
+			range: {
+				start_time: "1741500000:1741507200",
+			},
+			sortBy: "calls_2026_04:start_time:asc",
+			hitsPerPage: 40,
+		});
+	});
+});

--- a/frontend/src/lib/searchState.ts
+++ b/frontend/src/lib/searchState.ts
@@ -1,404 +1,607 @@
-const DEFAULT_INDEX_NAME = import.meta.env.VITE_MEILI_INDEX || 'calls'
-export const DEFAULT_MAX_ANALYSIS_HITS = 200
+const DEFAULT_INDEX_NAME = import.meta.env.VITE_MEILI_INDEX || "calls";
+export const DEFAULT_MAX_ANALYSIS_HITS = 200;
 
 const SUPPORTED_REFINEMENT_ATTRIBUTES = [
-  'radios',
-  'short_name',
-  'talkgroup_description',
-  'talkgroup_group',
-  'talkgroup_group_tag',
-  'talkgroup_tag',
-  'units',
-] as const
+	"radios",
+	"short_name",
+	"talkgroup_description",
+	"talkgroup_group",
+	"talkgroup_group_tag",
+	"talkgroup_tag",
+	"units",
+] as const;
 
 const SUPPORTED_HIERARCHICAL_ATTRIBUTES = [
-  'talkgroup_hierarchy.lvl0',
-  'talkgroup_hierarchy.lvl1',
-  'talkgroup_hierarchy.lvl2',
-] as const
+	"talkgroup_hierarchy.lvl0",
+	"talkgroup_hierarchy.lvl1",
+	"talkgroup_hierarchy.lvl2",
+] as const;
 
 type SupportedRefinementAttribute =
-  (typeof SUPPORTED_REFINEMENT_ATTRIBUTES)[number]
+	(typeof SUPPORTED_REFINEMENT_ATTRIBUTES)[number];
 type SupportedHierarchicalAttribute =
-  (typeof SUPPORTED_HIERARCHICAL_ATTRIBUTES)[number]
+	(typeof SUPPORTED_HIERARCHICAL_ATTRIBUTES)[number];
 
 export interface ScannerSearchScope {
-  query?: string
-  refinementList?: Partial<Record<SupportedRefinementAttribute, string[]>>
-  hierarchicalMenu?: Partial<Record<SupportedHierarchicalAttribute, string>>
-  range?: {
-    start_time?: string
-  }
-  maxHits?: number
+	query?: string;
+	refinementList?: Partial<Record<SupportedRefinementAttribute, string[]>>;
+	hierarchicalMenu?: Partial<Record<SupportedHierarchicalAttribute, string>>;
+	range?: {
+		start_time?: string;
+	};
+	maxHits?: number;
 }
 
 export interface ScannerSearchUiState
-  extends Omit<ScannerSearchScope, 'maxHits'> {
-  hitsPerPage?: number
-  sortBy?: string
+	extends Omit<ScannerSearchScope, "maxHits"> {
+	hitsPerPage?: number;
+	sortBy?: string;
 }
 
 export interface BuildScannerSearchUrlInput {
-  scope?: ScannerSearchScope
-  callId?: string
-  callStartTime?: number
-  focusWindowSeconds?: number
-  indexName?: string
-  hitsPerPage?: number
-  sortBy?: string
+	scope?: ScannerSearchScope;
+	callId?: string;
+	callStartTime?: number;
+	focusWindowSeconds?: number;
+	indexName?: string;
+	hitsPerPage?: number;
+	sortBy?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function appendSearchParam(
-  searchParams: URLSearchParams,
-  key: string,
-  value: unknown,
+	searchParams: URLSearchParams,
+	key: string,
+	value: unknown,
 ): void {
-  if (value === undefined || value === null || value === '') {
-    return
-  }
+	if (value === undefined || value === null || value === "") {
+		return;
+	}
 
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => {
-      appendSearchParam(searchParams, `${key}[${index}]`, item)
-    })
-    return
-  }
+	if (Array.isArray(value)) {
+		value.forEach((item, index) => {
+			appendSearchParam(searchParams, `${key}[${index}]`, item);
+		});
+		return;
+	}
 
-  if (isRecord(value)) {
-    for (const [nestedKey, nestedValue] of Object.entries(value)) {
-      appendSearchParam(searchParams, `${key}[${nestedKey}]`, nestedValue)
-    }
-    return
-  }
+	if (isRecord(value)) {
+		for (const [nestedKey, nestedValue] of Object.entries(value)) {
+			appendSearchParam(searchParams, `${key}[${nestedKey}]`, nestedValue);
+		}
+		return;
+	}
 
-  searchParams.append(key, String(value))
+	searchParams.append(key, String(value));
 }
 
 export function toEpochSeconds(value: string | undefined): number | undefined {
-  if (!value) {
-    return undefined
-  }
+	if (!value) {
+		return undefined;
+	}
 
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return undefined
-  }
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		return undefined;
+	}
 
-  return Math.floor(parsed.getTime() / 1000)
+	return Math.floor(parsed.getTime() / 1000);
 }
 
 export function toLocalDateTimeValue(value: Date): string {
-  const year = value.getFullYear()
-  const month = `${value.getMonth() + 1}`.padStart(2, '0')
-  const day = `${value.getDate()}`.padStart(2, '0')
-  const hours = `${value.getHours()}`.padStart(2, '0')
-  const minutes = `${value.getMinutes()}`.padStart(2, '0')
-  return `${year}-${month}-${day}T${hours}:${minutes}`
+	const year = value.getFullYear();
+	const month = `${value.getMonth() + 1}`.padStart(2, "0");
+	const day = `${value.getDate()}`.padStart(2, "0");
+	const hours = `${value.getHours()}`.padStart(2, "0");
+	const minutes = `${value.getMinutes()}`.padStart(2, "0");
+	return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
 export function epochSecondsToLocalDateTimeValue(
-  value: number | undefined,
+	value: number | undefined,
 ): string {
-  if (value === undefined || !Number.isFinite(value)) {
-    return ''
-  }
+	if (value === undefined || !Number.isFinite(value)) {
+		return "";
+	}
 
-  return toLocalDateTimeValue(new Date(value * 1000))
+	return toLocalDateTimeValue(new Date(value * 1000));
 }
 
 function hashString(value: string): string {
-  let hash = 0
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) >>> 0
-  }
-  return hash.toString(16).padStart(8, '0')
+	let hash = 0;
+	for (let index = 0; index < value.length; index += 1) {
+		hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+	}
+	return hash.toString(16).padStart(8, "0");
 }
 
 function sortRecord<T extends string | string[]>(
-  value: Record<string, T> | undefined,
+	value: Record<string, T> | undefined,
 ): Record<string, T> | undefined {
-  if (!value) {
-    return undefined
-  }
+	if (!value) {
+		return undefined;
+	}
 
-  const entries = Object.entries(value).sort(([left], [right]) =>
-    left.localeCompare(right),
-  )
-  if (entries.length === 0) {
-    return undefined
-  }
+	const entries = Object.entries(value).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	if (entries.length === 0) {
+		return undefined;
+	}
 
-  return Object.fromEntries(entries)
+	return Object.fromEntries(entries);
 }
 
 function normalizeStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined
-  }
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
 
-  const normalized = Array.from(
-    new Set(
-      value
-        .map((item) => (typeof item === 'string' ? item.trim() : ''))
-        .filter(Boolean),
-    ),
-  ).sort((left, right) => left.localeCompare(right))
+	const normalized = Array.from(
+		new Set(
+			value
+				.map((item) => (typeof item === "string" ? item.trim() : ""))
+				.filter(Boolean),
+		),
+	).sort((left, right) => left.localeCompare(right));
 
-  return normalized.length > 0 ? normalized : undefined
+	return normalized.length > 0 ? normalized : undefined;
 }
 
 function normalizeRangeValue(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined
-  }
+	if (typeof value !== "string") {
+		return undefined;
+	}
 
-  const trimmed = value.trim()
-  if (!trimmed || !trimmed.includes(':')) {
-    return undefined
-  }
-  return trimmed
+	const trimmed = value.trim();
+	if (!trimmed || !trimmed.includes(":")) {
+		return undefined;
+	}
+	return trimmed;
 }
 
 function normalizeSortByValue(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined
-  }
+	if (typeof value !== "string") {
+		return undefined;
+	}
 
-  const trimmed = value.trim()
-  return trimmed ? trimmed : undefined
+	const trimmed = value.trim();
+	return trimmed ? trimmed : undefined;
 }
 
 function normalizeHitsPerPageValue(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return undefined
-  }
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return undefined;
+	}
 
-  const normalized = Math.floor(value)
-  return normalized > 0 ? normalized : undefined
+	const normalized = Math.floor(value);
+	return normalized > 0 ? normalized : undefined;
 }
 
 function normalizeSearchScope(scope: ScannerSearchScope): ScannerSearchScope {
-  const normalizedRefinementList = sortRecord(
-    Object.fromEntries(
-      SUPPORTED_REFINEMENT_ATTRIBUTES.flatMap((attribute) => {
-        const values = normalizeStringArray(scope.refinementList?.[attribute])
-        return values ? [[attribute, values]] : []
-      }),
-    ) as ScannerSearchScope['refinementList'],
-  )
+	const normalizedRefinementList = sortRecord(
+		Object.fromEntries(
+			SUPPORTED_REFINEMENT_ATTRIBUTES.flatMap((attribute) => {
+				const values = normalizeStringArray(scope.refinementList?.[attribute]);
+				return values ? [[attribute, values]] : [];
+			}),
+		) as ScannerSearchScope["refinementList"],
+	);
 
-  const normalizedHierarchicalMenu = sortRecord(
-    Object.fromEntries(
-      SUPPORTED_HIERARCHICAL_ATTRIBUTES.flatMap((attribute) => {
-        const value = scope.hierarchicalMenu?.[attribute]?.trim()
-        return value ? [[attribute, value]] : []
-      }),
-    ) as ScannerSearchScope['hierarchicalMenu'],
-  )
+	const normalizedHierarchicalMenu = sortRecord(
+		Object.fromEntries(
+			SUPPORTED_HIERARCHICAL_ATTRIBUTES.flatMap((attribute) => {
+				const value = scope.hierarchicalMenu?.[attribute]?.trim();
+				return value ? [[attribute, value]] : [];
+			}),
+		) as ScannerSearchScope["hierarchicalMenu"],
+	);
 
-  const normalizedRange = normalizeRangeValue(scope.range?.start_time)
-    ? { start_time: normalizeRangeValue(scope.range?.start_time) }
-    : undefined
+	const normalizedRange = normalizeRangeValue(scope.range?.start_time)
+		? { start_time: normalizeRangeValue(scope.range?.start_time) }
+		: undefined;
 
-  const query = scope.query?.trim()
+	const query = scope.query?.trim();
 
-  return {
-    ...(query ? { query } : {}),
-    ...(normalizedRefinementList ? { refinementList: normalizedRefinementList } : {}),
-    ...(normalizedHierarchicalMenu
-      ? { hierarchicalMenu: normalizedHierarchicalMenu }
-      : {}),
-    ...(normalizedRange ? { range: normalizedRange } : {}),
-    ...(scope.maxHits ? { maxHits: scope.maxHits } : {}),
-  }
+	return {
+		...(query ? { query } : {}),
+		...(normalizedRefinementList
+			? { refinementList: normalizedRefinementList }
+			: {}),
+		...(normalizedHierarchicalMenu
+			? { hierarchicalMenu: normalizedHierarchicalMenu }
+			: {}),
+		...(normalizedRange ? { range: normalizedRange } : {}),
+		...(scope.maxHits ? { maxHits: scope.maxHits } : {}),
+	};
 }
 
 export function extractScannerSearchScope(
-  indexUiState: Record<string, unknown> | undefined,
-  maxHits: number = DEFAULT_MAX_ANALYSIS_HITS,
+	indexUiState: Record<string, unknown> | undefined,
+	maxHits: number = DEFAULT_MAX_ANALYSIS_HITS,
 ): ScannerSearchScope {
-  const refinementList = isRecord(indexUiState?.refinementList)
-    ? (indexUiState?.refinementList as Record<string, unknown>)
-    : undefined
-  const hierarchicalMenu = isRecord(indexUiState?.hierarchicalMenu)
-    ? (indexUiState?.hierarchicalMenu as Record<string, unknown>)
-    : undefined
-  const range = isRecord(indexUiState?.range)
-    ? (indexUiState?.range as Record<string, unknown>)
-    : undefined
+	const refinementList = isRecord(indexUiState?.refinementList)
+		? (indexUiState?.refinementList as Record<string, unknown>)
+		: undefined;
+	const hierarchicalMenu = isRecord(indexUiState?.hierarchicalMenu)
+		? (indexUiState?.hierarchicalMenu as Record<string, unknown>)
+		: undefined;
+	const range = isRecord(indexUiState?.range)
+		? (indexUiState?.range as Record<string, unknown>)
+		: undefined;
 
-  return normalizeSearchScope({
-    query: typeof indexUiState?.query === 'string' ? indexUiState.query : undefined,
-    refinementList: Object.fromEntries(
-      SUPPORTED_REFINEMENT_ATTRIBUTES.flatMap((attribute) => {
-        const values = normalizeStringArray(refinementList?.[attribute])
-        return values ? [[attribute, values]] : []
-      }),
-    ),
-    hierarchicalMenu: Object.fromEntries(
-      SUPPORTED_HIERARCHICAL_ATTRIBUTES.flatMap((attribute) => {
-        const value =
-          typeof hierarchicalMenu?.[attribute] === 'string'
-            ? hierarchicalMenu[attribute].trim()
-            : ''
-        return value ? [[attribute, value]] : []
-      }),
-    ),
-    range: {
-      start_time: normalizeRangeValue(range?.start_time),
-    },
-    maxHits,
-  })
+	return normalizeSearchScope({
+		query:
+			typeof indexUiState?.query === "string" ? indexUiState.query : undefined,
+		refinementList: Object.fromEntries(
+			SUPPORTED_REFINEMENT_ATTRIBUTES.flatMap((attribute) => {
+				const values = normalizeStringArray(refinementList?.[attribute]);
+				return values ? [[attribute, values]] : [];
+			}),
+		),
+		hierarchicalMenu: Object.fromEntries(
+			SUPPORTED_HIERARCHICAL_ATTRIBUTES.flatMap((attribute) => {
+				const value =
+					typeof hierarchicalMenu?.[attribute] === "string"
+						? hierarchicalMenu[attribute].trim()
+						: "";
+				return value ? [[attribute, value]] : [];
+			}),
+		),
+		range: {
+			start_time: normalizeRangeValue(range?.start_time),
+		},
+		maxHits,
+	});
 }
 
 export function extractScannerSearchUiState(
-  indexUiState: Record<string, unknown> | undefined,
+	indexUiState: Record<string, unknown> | undefined,
 ): ScannerSearchUiState {
-  const scope = extractScannerSearchScope(indexUiState)
-  const { maxHits: _maxHits, ...savedScope } = scope
-  const sortBy = normalizeSortByValue(indexUiState?.sortBy)
-  const hitsPerPage = normalizeHitsPerPageValue(indexUiState?.hitsPerPage)
+	const scope = extractScannerSearchScope(indexUiState);
+	const { maxHits: _maxHits, ...savedScope } = scope;
+	const sortBy = normalizeSortByValue(indexUiState?.sortBy);
+	const hitsPerPage = normalizeHitsPerPageValue(indexUiState?.hitsPerPage);
 
-  return {
-    ...savedScope,
-    ...(sortBy ? { sortBy } : {}),
-    ...(hitsPerPage ? { hitsPerPage } : {}),
-  }
+	return {
+		...savedScope,
+		...(sortBy ? { sortBy } : {}),
+		...(hitsPerPage ? { hitsPerPage } : {}),
+	};
 }
 
 export function createScannerChatThreadId(scope: ScannerSearchScope): string {
-  return `scanner-chat-${hashString(JSON.stringify(normalizeSearchScope(scope)))}`
+	return `scanner-chat-${hashString(JSON.stringify(normalizeSearchScope(scope)))}`;
 }
 
 function summarizeRange(range: string | undefined): string | undefined {
-  if (!range) {
-    return undefined
-  }
+	if (!range) {
+		return undefined;
+	}
 
-  const [start, end] = range.split(':', 2)
-  const startValue = epochSecondsToLocalDateTimeValue(Number(start))
-  const endValue = epochSecondsToLocalDateTimeValue(Number(end))
-  if (!startValue && !endValue) {
-    return undefined
-  }
-  return `${startValue || 'open'} to ${endValue || 'open'}`
+	const [start, end] = range.split(":", 2);
+	const startValue = epochSecondsToLocalDateTimeValue(Number(start));
+	const endValue = epochSecondsToLocalDateTimeValue(Number(end));
+	if (!startValue && !endValue) {
+		return undefined;
+	}
+	return `${startValue || "open"} to ${endValue || "open"}`;
 }
 
-export function describeScannerSearchScope(scope: ScannerSearchScope): string[] {
-  const normalizedScope = normalizeSearchScope(scope)
-  const summary: string[] = []
+export function describeScannerSearchScope(
+	scope: ScannerSearchScope,
+): string[] {
+	const normalizedScope = normalizeSearchScope(scope);
+	const summary: string[] = [];
 
-  if (normalizedScope.query) {
-    summary.push(`Query: ${normalizedScope.query}`)
-  }
+	if (normalizedScope.query) {
+		summary.push(`Query: ${normalizedScope.query}`);
+	}
 
-  for (const attribute of SUPPORTED_REFINEMENT_ATTRIBUTES) {
-    const values = normalizedScope.refinementList?.[attribute]
-    if (values?.length) {
-      summary.push(`${attribute}: ${values.join(', ')}`)
-    }
-  }
+	for (const attribute of SUPPORTED_REFINEMENT_ATTRIBUTES) {
+		const values = normalizedScope.refinementList?.[attribute];
+		if (values?.length) {
+			summary.push(`${attribute}: ${values.join(", ")}`);
+		}
+	}
 
-  for (const attribute of SUPPORTED_HIERARCHICAL_ATTRIBUTES) {
-    const value = normalizedScope.hierarchicalMenu?.[attribute]
-    if (value) {
-      summary.push(`${attribute}: ${value}`)
-    }
-  }
+	for (const attribute of SUPPORTED_HIERARCHICAL_ATTRIBUTES) {
+		const value = normalizedScope.hierarchicalMenu?.[attribute];
+		if (value) {
+			summary.push(`${attribute}: ${value}`);
+		}
+	}
 
-  const rangeSummary = summarizeRange(normalizedScope.range?.start_time)
-  if (rangeSummary) {
-    summary.push(`Time: ${rangeSummary}`)
-  }
+	const rangeSummary = summarizeRange(normalizedScope.range?.start_time);
+	if (rangeSummary) {
+		summary.push(`Time: ${rangeSummary}`);
+	}
 
-  return summary
+	return summary;
 }
 
 export function isBroadScannerSearchScope(scope: ScannerSearchScope): boolean {
-  const normalizedScope = normalizeSearchScope(scope)
-  return (
-    !normalizedScope.query &&
-    !normalizedScope.range?.start_time &&
-    !normalizedScope.refinementList &&
-    !normalizedScope.hierarchicalMenu
-  )
+	const normalizedScope = normalizeSearchScope(scope);
+	return (
+		!normalizedScope.query &&
+		!normalizedScope.range?.start_time &&
+		!normalizedScope.refinementList &&
+		!normalizedScope.hierarchicalMenu
+	);
 }
 
-export function buildScannerChatInstructions(scope: ScannerSearchScope): string {
-  const normalizedScope = normalizeSearchScope(scope)
-  const scopeLines = ['Active transcript search scope for this chat session:']
+export function buildScannerChatInstructions(
+	scope: ScannerSearchScope,
+): string {
+	const normalizedScope = normalizeSearchScope(scope);
+	const scopeLines = ["Active transcript search scope for this chat session:"];
 
-  const scopeSummary = describeScannerSearchScope(normalizedScope)
-  if (scopeSummary.length === 0) {
-    scopeLines.push('- No active query or refinements are applied yet.')
-  } else {
-    scopeSummary.forEach((line) => scopeLines.push(`- ${line}`))
-  }
+	const scopeSummary = describeScannerSearchScope(normalizedScope);
+	if (scopeSummary.length === 0) {
+		scopeLines.push("- No active query or refinements are applied yet.");
+	} else {
+		scopeSummary.forEach((line) => scopeLines.push(`- ${line}`));
+	}
 
-  scopeLines.push(
-    `- Maximum transcript analysis depth: ${normalizedScope.maxHits || DEFAULT_MAX_ANALYSIS_HITS} matching calls.`,
-  )
-  scopeLines.push(
-    '- Call `get_current_search_scope` before transcript analysis unless the user explicitly asks to change filters.',
-  )
-  scopeLines.push(
-    '- Use `search_transcripts` with that exact scope so your evidence matches the visible search results.',
-  )
-  scopeLines.push(
-    '- If the user wants to inspect evidence in the main search UI, use the frontend search navigation tools.',
-  )
-  scopeLines.push(`Exact scope JSON: ${JSON.stringify(normalizedScope)}`)
+	scopeLines.push(
+		`- Maximum transcript analysis depth: ${normalizedScope.maxHits || DEFAULT_MAX_ANALYSIS_HITS} matching calls.`,
+	);
+	scopeLines.push(
+		"- Call `get_current_search_scope` before transcript analysis unless the user explicitly asks to change filters.",
+	);
+	scopeLines.push(
+		"- Use `search_transcripts` with that exact scope so your evidence matches the visible search results.",
+	);
+	scopeLines.push(
+		"- If the user wants to inspect evidence in the main search UI, use the frontend search navigation tools.",
+	);
+	scopeLines.push(`Exact scope JSON: ${JSON.stringify(normalizedScope)}`);
 
-  return scopeLines.join('\n')
+	return scopeLines.join("\n");
 }
 
 export function buildScannerSearchUrl(
-  input: BuildScannerSearchUrlInput,
+	input: BuildScannerSearchUrlInput,
 ): string {
-  const scope = normalizeSearchScope(input.scope || {})
-  const indexName = input.indexName || DEFAULT_INDEX_NAME
-  const hitsPerPage = input.hitsPerPage || 60
-  const focusWindowSeconds = input.focusWindowSeconds || 30 * 60
-  const sortBy = input.sortBy || `${indexName}:start_time:desc`
+	const scope = normalizeSearchScope(input.scope || {});
+	const indexName = input.indexName || DEFAULT_INDEX_NAME;
+	const hitsPerPage = input.hitsPerPage || 60;
+	const focusWindowSeconds = input.focusWindowSeconds || 30 * 60;
+	const sortBy = input.sortBy || `${indexName}:start_time:desc`;
 
-  const indexState: Record<string, unknown> = {
-    sortBy,
-    hitsPerPage,
-  }
+	const indexState: Record<string, unknown> = {
+		sortBy,
+		hitsPerPage,
+	};
 
-  if (scope.query) {
-    indexState.query = scope.query
-  }
+	if (scope.query) {
+		indexState.query = scope.query;
+	}
 
-  if (scope.refinementList && Object.keys(scope.refinementList).length > 0) {
-    indexState.refinementList = scope.refinementList
-  }
+	if (scope.refinementList && Object.keys(scope.refinementList).length > 0) {
+		indexState.refinementList = scope.refinementList;
+	}
 
-  if (scope.hierarchicalMenu && Object.keys(scope.hierarchicalMenu).length > 0) {
-    indexState.hierarchicalMenu = scope.hierarchicalMenu
-  }
+	if (
+		scope.hierarchicalMenu &&
+		Object.keys(scope.hierarchicalMenu).length > 0
+	) {
+		indexState.hierarchicalMenu = scope.hierarchicalMenu;
+	}
 
-  if (scope.range?.start_time) {
-    indexState.range = scope.range
-  } else if (input.callStartTime !== undefined) {
-    indexState.range = {
-      start_time: `${input.callStartTime - focusWindowSeconds}:${input.callStartTime + focusWindowSeconds}`,
-    }
-  }
+	if (scope.range?.start_time) {
+		indexState.range = scope.range;
+	} else if (input.callStartTime !== undefined) {
+		indexState.range = {
+			start_time: `${input.callStartTime - focusWindowSeconds}:${input.callStartTime + focusWindowSeconds}`,
+		};
+	}
 
-  const searchParams = new URLSearchParams()
-  appendSearchParam(searchParams, indexName, indexState)
+	const searchParams = new URLSearchParams();
+	appendSearchParam(searchParams, indexName, indexState);
 
-  const search = searchParams.toString()
-  const hash = input.callId ? `#hit-${input.callId}` : ''
+	const search = searchParams.toString();
+	const hash = input.callId ? `#hit-${input.callId}` : "";
 
-  if (!search) {
-    return `/${hash}`
-  }
+	if (!search) {
+		return `/${hash}`;
+	}
 
-  return `/?${search}${hash}`
+	return `/?${search}${hash}`;
+}
+
+type ScannerSearchParamPathSegment = string | number;
+
+function parseSearchParamKey(
+	key: string,
+): { root: string; path: ScannerSearchParamPathSegment[] } | null {
+	const bracketIndex = key.indexOf("[");
+	if (bracketIndex === -1) {
+		return null;
+	}
+
+	const root = key.slice(0, bracketIndex);
+	if (!root) {
+		return null;
+	}
+
+	const path: ScannerSearchParamPathSegment[] = [];
+	let cursor = bracketIndex;
+
+	while (cursor < key.length && key[cursor] === "[") {
+		const endIndex = key.indexOf("]", cursor + 1);
+		if (endIndex === -1) {
+			break;
+		}
+
+		const segment = key.slice(cursor + 1, endIndex);
+		if (!segment) {
+			break;
+		}
+
+		const numeric = Number.parseInt(segment, 10);
+		path.push(
+			`${numeric}` === segment && Number.isFinite(numeric) ? numeric : segment,
+		);
+		cursor = endIndex + 1;
+	}
+
+	return path.length > 0 ? { root, path } : null;
+}
+
+function ensureContainer(
+	parent: Record<string, unknown> | unknown[],
+	key: ScannerSearchParamPathSegment,
+	nextKey: ScannerSearchParamPathSegment,
+): Record<string, unknown> | unknown[] {
+	const shouldBeArray = typeof nextKey === "number";
+
+	if (typeof key === "number") {
+		const parentArray = Array.isArray(parent) ? parent : [];
+		const existing = parentArray[key];
+		if (shouldBeArray) {
+			if (!Array.isArray(existing)) {
+				parentArray[key] = [];
+			}
+			return parentArray[key] as unknown[];
+		}
+
+		if (
+			typeof existing !== "object" ||
+			existing === null ||
+			Array.isArray(existing)
+		) {
+			parentArray[key] = {};
+		}
+
+		return parentArray[key] as Record<string, unknown>;
+	}
+
+	const parentObject =
+		typeof parent === "object" && parent !== null && !Array.isArray(parent)
+			? (parent as Record<string, unknown>)
+			: {};
+
+	const existing = parentObject[key];
+	if (shouldBeArray) {
+		if (!Array.isArray(existing)) {
+			parentObject[key] = [];
+		}
+		return parentObject[key] as unknown[];
+	}
+
+	if (
+		typeof existing !== "object" ||
+		existing === null ||
+		Array.isArray(existing)
+	) {
+		parentObject[key] = {};
+	}
+
+	return parentObject[key] as Record<string, unknown>;
+}
+
+function assignSearchParamValue(
+	root: Record<string, unknown>,
+	path: ScannerSearchParamPathSegment[],
+	value: string,
+): void {
+	let cursor: Record<string, unknown> | unknown[] = root;
+
+	for (let index = 0; index < path.length; index += 1) {
+		const segment = path[index];
+		const isLast = index === path.length - 1;
+
+		if (isLast) {
+			if (typeof segment === "number") {
+				if (!Array.isArray(cursor)) {
+					return;
+				}
+				cursor[segment] = value;
+				return;
+			}
+
+			if (
+				typeof cursor !== "object" ||
+				cursor === null ||
+				Array.isArray(cursor)
+			) {
+				return;
+			}
+
+			cursor[segment] = value;
+			return;
+		}
+
+		const nextSegment = path[index + 1];
+		const nextContainer = ensureContainer(cursor, segment, nextSegment);
+
+		if (typeof segment === "number") {
+			if (!Array.isArray(cursor)) {
+				return;
+			}
+			cursor[segment] = nextContainer;
+		} else if (
+			typeof cursor === "object" &&
+			cursor !== null &&
+			!Array.isArray(cursor)
+		) {
+			cursor[segment] = nextContainer;
+		}
+
+		cursor = nextContainer;
+	}
+}
+
+export type ParsedScannerSearchUrl = {
+	indexName: string;
+	indexUiState: Record<string, unknown>;
+	state: ScannerSearchUiState;
+};
+
+export function parseScannerSearchUrl(
+	url: string,
+): ParsedScannerSearchUrl | null {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(url, "http://localhost");
+	} catch {
+		return null;
+	}
+
+	const statesByIndexName: Record<string, Record<string, unknown>> = {};
+
+	for (const [key, value] of parsedUrl.searchParams.entries()) {
+		const parsedKey = parseSearchParamKey(key);
+		if (!parsedKey) {
+			continue;
+		}
+
+		const indexUiState = (statesByIndexName[parsedKey.root] ??= {}) as Record<
+			string,
+			unknown
+		>;
+		assignSearchParamValue(indexUiState, parsedKey.path, value);
+	}
+
+	const indexName = Object.keys(statesByIndexName)[0];
+	if (!indexName) {
+		return null;
+	}
+
+	const indexUiState = statesByIndexName[indexName];
+	if (typeof indexUiState.hitsPerPage === "string") {
+		const parsedHitsPerPage = Number.parseInt(indexUiState.hitsPerPage, 10);
+		if (Number.isFinite(parsedHitsPerPage)) {
+			indexUiState.hitsPerPage = parsedHitsPerPage;
+		}
+	}
+	return {
+		indexName,
+		indexUiState,
+		state: extractScannerSearchUiState(indexUiState),
+	};
 }

--- a/frontend/src/providers/AppProviders.tsx
+++ b/frontend/src/providers/AppProviders.tsx
@@ -1,19 +1,33 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { AuthProvider } from "./auth";
 import { EntitlementsProvider } from "./entitlements";
 import { NotificationsProvider } from "./notifications";
-import { SavedSearchStoreProvider } from "./savedSearchStore";
+import {
+	SavedSearchStoreProvider,
+	createSirensBackendSavedSearchStore,
+} from "./savedSearchStore";
 import { SearchCredentialsProvider } from "./searchCredentials";
 import { ViewerProvider } from "./viewer";
 
 export function AppProviders({ children }: { children: ReactNode }) {
+	const sirensApiBaseUrl = import.meta.env.VITE_SIRENS_API_BASE_URL;
+	const savedSearchStore = useMemo(() => {
+		if (!sirensApiBaseUrl) {
+			return undefined;
+		}
+
+		return createSirensBackendSavedSearchStore({
+			apiBaseUrl: sirensApiBaseUrl,
+		});
+	}, [sirensApiBaseUrl]);
+
 	return (
 		<AuthProvider>
 			<ViewerProvider>
 				<EntitlementsProvider>
 					<SearchCredentialsProvider>
-						<SavedSearchStoreProvider>
+						<SavedSearchStoreProvider store={savedSearchStore}>
 							<NotificationsProvider>{children}</NotificationsProvider>
 						</SavedSearchStoreProvider>
 					</SearchCredentialsProvider>
@@ -22,4 +36,3 @@ export function AppProviders({ children }: { children: ReactNode }) {
 		</AuthProvider>
 	);
 }
-

--- a/frontend/src/providers/savedSearchStore.tsx
+++ b/frontend/src/providers/savedSearchStore.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, type ReactNode } from "react";
 
-import type { ScannerSearchUiState } from "@/lib/searchState";
 import {
+	parseScannerSearchUrl,
+	type ScannerSearchUiState,
+} from "@/lib/searchState";
+import {
+	buildTranscriptSavedSearchUrl,
 	createTranscriptSavedSearchEntryFromState,
 	deleteTranscriptSavedSearchEntry,
 	loadTranscriptSavedSearches,
@@ -16,15 +20,19 @@ export type SavedSearchStore = {
 	create: (
 		name: string,
 		state: ScannerSearchUiState,
+		indexName?: string,
 	) => Promise<TranscriptSavedSearchEntry>;
 	update: (
 		id: string,
 		state: ScannerSearchUiState,
+		indexName?: string,
 	) => Promise<TranscriptSavedSearchEntry>;
 	remove: (id: string) => Promise<void>;
 };
 
-export type SavedSearchStorage = Parameters<typeof loadTranscriptSavedSearches>[0];
+export type SavedSearchStorage = Parameters<
+	typeof loadTranscriptSavedSearches
+>[0];
 
 export function createLocalStorageSavedSearchStore(
 	storage?: SavedSearchStorage,
@@ -34,21 +42,24 @@ export function createLocalStorageSavedSearchStore(
 			return loadTranscriptSavedSearches(storage);
 		},
 
-		async create(name, state) {
+		async create(name, state, _indexName) {
 			const entries = loadTranscriptSavedSearches(storage);
 			const created = createTranscriptSavedSearchEntryFromState(name, state);
 			persistTranscriptSavedSearches([...entries, created], storage);
 			return created;
 		},
 
-		async update(id, state) {
+		async update(id, state, _indexName) {
 			const entries = loadTranscriptSavedSearches(storage);
 			const existing = entries.find((entry) => entry.id === id);
 			if (!existing) {
 				throw new Error(`Saved search not found: ${id}`);
 			}
 
-			const updated = updateTranscriptSavedSearchEntryFromState(existing, state);
+			const updated = updateTranscriptSavedSearchEntryFromState(
+				existing,
+				state,
+			);
 			persistTranscriptSavedSearches(
 				upsertTranscriptSavedSearchEntry(entries, updated),
 				storage,
@@ -58,7 +69,191 @@ export function createLocalStorageSavedSearchStore(
 
 		async remove(id) {
 			const entries = loadTranscriptSavedSearches(storage);
-			persistTranscriptSavedSearches(deleteTranscriptSavedSearchEntry(entries, id), storage);
+			persistTranscriptSavedSearches(
+				deleteTranscriptSavedSearchEntry(entries, id),
+				storage,
+			);
+		},
+	};
+}
+
+type SirensSavedSearch = {
+	id: number | string;
+	name: string;
+	url: string;
+	created_at?: string;
+	updated_at?: string;
+};
+
+function trimTrailingSlash(value: string): string {
+	return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function getXsrfToken(): string | null {
+	if (typeof document === "undefined") {
+		return null;
+	}
+
+	const tokenCookie = document.cookie
+		.split("; ")
+		.find((row) => row.startsWith("XSRF-TOKEN="))
+		?.split("=")[1];
+
+	return tokenCookie ? decodeURIComponent(tokenCookie) : null;
+}
+
+function sortEntries(
+	entries: TranscriptSavedSearchEntry[],
+): TranscriptSavedSearchEntry[] {
+	return [...entries].sort((left, right) =>
+		right.updatedAt.localeCompare(left.updatedAt),
+	);
+}
+
+function toTranscriptSavedSearchEntry(
+	value: SirensSavedSearch,
+): TranscriptSavedSearchEntry | null {
+	const parsed = parseScannerSearchUrl(value.url);
+	if (!parsed) {
+		return null;
+	}
+
+	const now = new Date().toISOString();
+	return {
+		id: String(value.id),
+		name: value.name,
+		state: parsed.state,
+		createdAt: value.created_at || now,
+		updatedAt: value.updated_at || value.created_at || now,
+	};
+}
+
+async function readSirensJson(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("Content-Type") || "";
+	if (contentType.includes("application/json")) {
+		return response.json();
+	}
+	return response.text();
+}
+
+export function createSirensBackendSavedSearchStore({
+	apiBaseUrl,
+}: {
+	apiBaseUrl: string;
+}): SavedSearchStore {
+	const baseUrl = trimTrailingSlash(apiBaseUrl);
+
+	return {
+		async list() {
+			const response = await fetch(`${baseUrl}/api/savedSearches`, {
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+				},
+			});
+			if (!response.ok) {
+				throw new Error(`Failed to load saved searches (${response.status})`);
+			}
+
+			const payload = await response.json();
+			const entries = Array.isArray(payload)
+				? payload
+						.map((item) =>
+							toTranscriptSavedSearchEntry(item as SirensSavedSearch),
+						)
+						.filter(
+							(entry): entry is TranscriptSavedSearchEntry => entry !== null,
+						)
+				: [];
+
+			return sortEntries(entries);
+		},
+
+		async create(name, state, indexName) {
+			const xsrfToken = getXsrfToken();
+			const url = buildTranscriptSavedSearchUrl(
+				indexName || import.meta.env.VITE_MEILI_INDEX || "calls",
+				state,
+			);
+
+			const response = await fetch(`${baseUrl}/api/savedSearches`, {
+				method: "POST",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					name,
+					url,
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to create saved search (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = (await response.json()) as SirensSavedSearch;
+			const entry = toTranscriptSavedSearchEntry(payload);
+			if (!entry) {
+				throw new Error("Saved search was created but could not be parsed");
+			}
+			return entry;
+		},
+
+		async update(id, state, indexName) {
+			const xsrfToken = getXsrfToken();
+			const url = buildTranscriptSavedSearchUrl(
+				indexName || import.meta.env.VITE_MEILI_INDEX || "calls",
+				state,
+			);
+
+			const response = await fetch(`${baseUrl}/api/savedSearches/${id}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					url,
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to update saved search (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = (await response.json()) as SirensSavedSearch;
+			const entry = toTranscriptSavedSearchEntry(payload);
+			if (!entry) {
+				throw new Error("Saved search was updated but could not be parsed");
+			}
+			return entry;
+		},
+
+		async remove(id) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/savedSearches/${id}`, {
+				method: "DELETE",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to delete saved search (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
 		},
 	};
 }
@@ -86,4 +281,3 @@ export function SavedSearchStoreProvider({
 export function useSavedSearchStore(): SavedSearchStore {
 	return useContext(SavedSearchStoreContext);
 }
-


### PR DESCRIPTION
Implements `CRI-64` by adding a Sirens/Laravel-backed `SavedSearchStore` adapter:

- Adds `parseScannerSearchUrl` to reconstruct normalized `ScannerSearchUiState` from saved-search URLs.
- Adds `createSirensBackendSavedSearchStore({ apiBaseUrl })` that talks to `/api/savedSearches` with cookie auth + XSRF header for writes.
- Updates `AppProviders` to use the backend store when `VITE_SIRENS_API_BASE_URL` is set.
- Updates the Saved Searches UI to pass `indexName` through for backend URL generation.

Local verification: `cd frontend && npm test`.