### PR TITLE
Frontend: use Sirens backend-issued scoped search credentials (CRI-66)

### DIFF
--- a/frontend/src/providers/searchCredentials.tsx
+++ b/frontend/src/providers/searchCredentials.tsx
@@ -11,6 +11,10 @@ export type SearchCredentialProvider = {
 	getTranscriptSearchCredentials: () => Promise<TranscriptSearchCredentials>;
 };
 
+function trimTrailingSlash(value: string): string {
+	return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
 export function createEnvSearchCredentialProvider(): SearchCredentialProvider {
 	return {
 		async getTranscriptSearchCredentials() {
@@ -18,13 +22,85 @@ export function createEnvSearchCredentialProvider(): SearchCredentialProvider {
 				hostUrl: import.meta.env.VITE_MEILI_URL || "http://localhost:7700",
 				apiKey: import.meta.env.VITE_MEILI_MASTER_KEY || "testing",
 				baseIndexName: import.meta.env.VITE_MEILI_INDEX || "calls",
-				splitByMonth: import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === "true",
+				splitByMonth:
+					import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === "true",
 			};
 		},
 	};
 }
 
-const defaultSearchCredentialProvider = createEnvSearchCredentialProvider();
+export function createSirensBackendSearchCredentialProvider({
+	apiBaseUrl,
+}: {
+	apiBaseUrl: string;
+}): SearchCredentialProvider {
+	const baseUrl = trimTrailingSlash(apiBaseUrl);
+
+	let cachedApiKey: string | null = null;
+	let inflight: Promise<string> | null = null;
+
+	async function fetchApiKey(): Promise<string> {
+		if (cachedApiKey) {
+			return cachedApiKey;
+		}
+
+		if (!inflight) {
+			inflight = fetch(`${baseUrl}/api/search-key`, {
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+				},
+			})
+				.then(async (response) => {
+					if (!response.ok) {
+						throw new Error(`Failed to fetch search key (${response.status})`);
+					}
+
+					const payload = (await response.json()) as { meilisearch?: unknown };
+					const apiKey = payload?.meilisearch;
+					if (typeof apiKey !== "string" || !apiKey) {
+						throw new Error(
+							"Search key response did not include meilisearch key",
+						);
+					}
+
+					cachedApiKey = apiKey;
+					return apiKey;
+				})
+				.finally(() => {
+					inflight = null;
+				});
+		}
+
+		return inflight;
+	}
+
+	return {
+		async getTranscriptSearchCredentials() {
+			const apiKey = await fetchApiKey();
+
+			return {
+				hostUrl: import.meta.env.VITE_MEILI_URL || "http://localhost:7700",
+				apiKey,
+				baseIndexName: import.meta.env.VITE_MEILI_INDEX || "calls",
+				splitByMonth:
+					import.meta.env.VITE_MEILI_INDEX_SPLIT_BY_MONTH === "true",
+			};
+		},
+	};
+}
+
+const defaultSearchCredentialProvider = (() => {
+	const sirensApiBaseUrl = import.meta.env.VITE_SIRENS_API_BASE_URL;
+	const explicitApiKey = import.meta.env.VITE_MEILI_MASTER_KEY;
+	if (sirensApiBaseUrl && !explicitApiKey) {
+		return createSirensBackendSearchCredentialProvider({
+			apiBaseUrl: sirensApiBaseUrl,
+		});
+	}
+
+	return createEnvSearchCredentialProvider();
+})();
 
 const SearchCredentialContext = createContext<SearchCredentialProvider>(
 	defaultSearchCredentialProvider,
@@ -49,4 +125,3 @@ export function SearchCredentialsProvider({
 export function useSearchCredentialProvider(): SearchCredentialProvider {
 	return useContext(SearchCredentialContext);
 }
-


### PR DESCRIPTION
Implements `CRI-66` by adding a Sirens backend adapter for transcript search credentials.

Behavior:
- If `VITE_MEILI_MASTER_KEY` is set, the frontend keeps using it (current behavior).
- Otherwise, if `VITE_SIRENS_API_BASE_URL` is set, the frontend fetches a scoped key from `${VITE_SIRENS_API_BASE_URL}/api/search-key` (cookie auth) and uses that as the Meilisearch API key.
- Otherwise it falls back to the existing local default (`testing`).

This keeps OSS/local behavior intact while enabling Sirens deployments to avoid shipping privileged search credentials.

Local verification: `cd frontend && npm test`.