### PR TITLE
Frontend: Alerts page + Sirens notifications/subscriptions adapter (CRI-67)

### DIFF
--- a/frontend/src/components/Alerts.tsx
+++ b/frontend/src/components/Alerts.tsx
@@ -1,0 +1,1013 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+	Alert,
+	Badge,
+	Button,
+	Col,
+	Form,
+	Modal,
+	Row,
+	Spinner,
+	Table,
+} from "react-bootstrap";
+
+import type { ScannerSearchUiState } from "@/lib/searchState";
+import {
+	describeTranscriptSavedSearchState,
+	type TranscriptSavedSearchEntry,
+} from "@/lib/transcriptSavedSearches";
+import { useAuth } from "@/providers/auth";
+import { useEntitlements } from "@/providers/entitlements";
+import type {
+	AvailableTalkgroupSystem,
+	CreateTranscriptSubscriptionInput,
+	NotificationChannel,
+	TranscriptSubscription,
+	UpdateNotificationChannelInput,
+	UpdateTranscriptSubscriptionInput,
+} from "@/providers/notifications";
+import { useNotifications } from "@/providers/notifications";
+import { useSavedSearchStore } from "@/providers/savedSearchStore";
+
+function parseCsv(input: string): string[] {
+	return input
+		.split(",")
+		.map((value) => value.trim())
+		.filter(Boolean);
+}
+
+type FlattenedTalkgroup = {
+	label: string;
+	group: string;
+	value: string;
+	systemId: string;
+};
+
+function flattenTalkgroups(systems: AvailableTalkgroupSystem[]): FlattenedTalkgroup[] {
+	return systems.flatMap((system) =>
+		system.talkgroups.flatMap((group) =>
+			group.talkgroups.flatMap((talkgroup) => {
+				const systemId = talkgroup.value.split("@")[1] ?? "";
+				return systemId
+					? [
+							{
+								label: talkgroup.label,
+								group: group.group,
+								value: talkgroup.value,
+								systemId,
+							},
+						]
+					: [];
+			}),
+		),
+	);
+}
+
+function deriveTopicFromSearchState(
+	state: ScannerSearchUiState,
+	availableTalkgroups: AvailableTalkgroupSystem[],
+): string | null {
+	const systemIds = state.refinementList?.short_name ?? [];
+	const talkgroupLabels = state.refinementList?.talkgroup_tag ?? [];
+	const groupLabels = state.refinementList?.talkgroup_group ?? [];
+
+	const talkgroups = flattenTalkgroups(availableTalkgroups);
+	const scopedBySystem = (entry: FlattenedTalkgroup): boolean =>
+		systemIds.length === 0 || systemIds.includes(entry.systemId);
+
+	const topicsFromTalkgroups = talkgroupLabels.length
+		? Array.from(
+				new Set(
+					talkgroups
+						.filter(scopedBySystem)
+						.filter((entry) => talkgroupLabels.includes(entry.label))
+						.map((entry) => entry.value),
+				),
+			)
+		: [];
+
+	if (topicsFromTalkgroups.length > 0) {
+		return topicsFromTalkgroups.join("|");
+	}
+
+	const topicsFromGroups = groupLabels.length
+		? Array.from(
+				new Set(
+					talkgroups
+						.filter(scopedBySystem)
+						.filter((entry) => groupLabels.includes(entry.group))
+						.map((entry) => entry.value),
+				),
+			)
+		: [];
+
+	if (topicsFromGroups.length > 0) {
+		return topicsFromGroups.join("|");
+	}
+
+	if (systemIds.length > 0) {
+		return systemIds.length === 1
+			? `.*@${systemIds[0]}`
+			: `.*@(${systemIds.join("|")})`;
+	}
+
+	return null;
+}
+
+export default function Alerts() {
+	const auth = useAuth();
+	const entitlements = useEntitlements();
+	const notifications = useNotifications();
+	const savedSearchStore = useSavedSearchStore();
+
+	const canCreateAlerts = entitlements.canCreateAlerts();
+
+	const [channels, setChannels] = useState<NotificationChannel[]>([]);
+	const [subscriptions, setSubscriptions] = useState<TranscriptSubscription[]>([]);
+	const [savedSearches, setSavedSearches] = useState<TranscriptSavedSearchEntry[]>([]);
+	const [talkgroups, setTalkgroups] = useState<AvailableTalkgroupSystem[]>([]);
+
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+
+	const [channelForm, setChannelForm] = useState({
+		service: "tgram",
+		path: "",
+	});
+	const [subscriptionForm, setSubscriptionForm] = useState<{
+		name: string;
+		enabled: boolean;
+		topic: string;
+		keywordsCsv: string;
+		ignoreKeywordsCsv: string;
+		notificationChannelIds: string[];
+	}>({
+		name: "",
+		enabled: true,
+		topic: "",
+		keywordsCsv: "",
+		ignoreKeywordsCsv: "",
+		notificationChannelIds: [],
+	});
+
+	const [selectedSavedSearchId, setSelectedSavedSearchId] = useState<string>("");
+
+	const [editingChannel, setEditingChannel] = useState<NotificationChannel | null>(null);
+	const [editingSubscription, setEditingSubscription] = useState<TranscriptSubscription | null>(
+		null,
+	);
+	const [isSaving, setIsSaving] = useState(false);
+	const [actionError, setActionError] = useState<string | null>(null);
+
+	const selectedSavedSearch = useMemo(
+		() => savedSearches.find((entry) => entry.id === selectedSavedSearchId) ?? null,
+		[savedSearches, selectedSavedSearchId],
+	);
+
+	async function refresh() {
+		setIsLoading(true);
+		setLoadError(null);
+
+		try {
+			const [nextChannels, nextSubscriptions, nextSavedSearches] = await Promise.all([
+				notifications.listNotificationChannels(),
+				notifications.listTranscriptSubscriptions(),
+				savedSearchStore.list(),
+			]);
+			setChannels(nextChannels);
+			setSubscriptions(nextSubscriptions);
+			setSavedSearches(nextSavedSearches);
+
+			try {
+				const nextTalkgroups = await notifications.listAvailableTalkgroups();
+				setTalkgroups(nextTalkgroups);
+			} catch {
+				// Talkgroup metadata is helpful for prefill but shouldn't block core alert CRUD.
+			}
+		} catch (error) {
+			setLoadError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	useEffect(() => {
+		if (auth.status !== "authenticated") {
+			return;
+		}
+
+		void refresh();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [auth.status]);
+
+	const isActionsEnabled = auth.status === "authenticated" && canCreateAlerts;
+
+	return (
+		<div className="container-fluid py-3">
+			<Row className="align-items-center mb-3">
+				<Col>
+					<h1 className="mb-0">Alerts</h1>
+					<div className="text-muted small">
+						Create notification channels and subscribe to transcript topics.
+					</div>
+				</Col>
+				<Col xs="auto">
+					<Button
+						type="button"
+						variant="outline-secondary"
+						disabled={auth.status !== "authenticated" || isLoading}
+						onClick={() => void refresh()}
+					>
+						Refresh
+					</Button>
+				</Col>
+			</Row>
+
+			{auth.status === "anonymous" ? (
+				<Alert variant="info">
+					<div className="d-flex flex-column flex-md-row align-items-start align-items-md-center justify-content-between gap-2">
+						<div>
+							<div className="fw-semibold">Sign in to manage alerts</div>
+							<div className="small">
+								Alerts are a Sirens feature. Sign in to create channels and
+								subscriptions.
+							</div>
+						</div>
+						<Button type="button" onClick={() => void auth.signIn()}>
+							Sign in
+						</Button>
+					</div>
+				</Alert>
+			) : null}
+
+			{auth.status === "authenticated" && !canCreateAlerts ? (
+				<Alert variant="warning">
+					<div className="fw-semibold">Alerts are not enabled for this account.</div>
+					<div className="small">
+						If you think this is a mistake, refresh or contact support.
+					</div>
+				</Alert>
+			) : null}
+
+			{loadError ? (
+				<Alert variant="danger">
+					<div className="fw-semibold">Failed to load alerts data</div>
+					<div className="small mt-1">{loadError}</div>
+				</Alert>
+			) : null}
+
+			{isLoading ? (
+				<Alert variant="secondary">
+					<Spinner animation="border" size="sm" className="me-2" />
+					Loading alerts…
+				</Alert>
+			) : null}
+
+			{actionError ? (
+				<Alert variant="danger" onClose={() => setActionError(null)} dismissible>
+					{actionError}
+				</Alert>
+			) : null}
+
+			<Row className="g-4">
+				<Col lg={5}>
+					<div className="border rounded p-3 bg-white">
+						<div className="d-flex align-items-center justify-content-between mb-2">
+							<div className="fw-semibold">Notification Channels</div>
+							<Badge bg="secondary">{channels.length}</Badge>
+						</div>
+
+						<Form
+							onSubmit={(event) => {
+								event.preventDefault();
+								if (!isActionsEnabled) {
+									return;
+								}
+
+								setIsSaving(true);
+								setActionError(null);
+								void notifications
+									.createNotificationChannel({
+										service: channelForm.service,
+										path: channelForm.path,
+									})
+									.then((created) => {
+										setChannels((prev) => [...prev, created]);
+										setChannelForm((prev) => ({ ...prev, path: "" }));
+									})
+									.catch((error) => {
+										setActionError(
+											error instanceof Error ? error.message : String(error),
+										);
+									})
+									.finally(() => setIsSaving(false));
+							}}
+						>
+							<Row className="g-2 align-items-end">
+								<Col xs={4}>
+									<Form.Label>Service</Form.Label>
+									<Form.Select
+										disabled={!isActionsEnabled || isSaving}
+										value={channelForm.service}
+										onChange={(event) =>
+											setChannelForm((prev) => ({
+												...prev,
+												service: event.target.value,
+											}))
+										}
+									>
+										<option value="tgram">Telegram</option>
+										<option value="ntfy">ntfy</option>
+										<option value="mailgun">Mailgun</option>
+										<option value="sns">AWS SNS</option>
+										<option value="ses">AWS SES</option>
+									</Form.Select>
+								</Col>
+								<Col>
+									<Form.Label>Path</Form.Label>
+									<Form.Control
+										disabled={!isActionsEnabled || isSaving}
+										value={channelForm.path}
+										placeholder="Channel identifier, email, topic, etc"
+										onChange={(event) =>
+											setChannelForm((prev) => ({
+												...prev,
+												path: event.target.value,
+											}))
+										}
+									/>
+								</Col>
+								<Col xs="auto">
+									<Button
+										type="submit"
+										disabled={!isActionsEnabled || isSaving || !channelForm.path.trim()}
+									>
+										Add
+									</Button>
+								</Col>
+							</Row>
+						</Form>
+
+						<div className="mt-3">
+							<Table size="sm" responsive bordered>
+								<thead>
+									<tr>
+										<th>Service</th>
+										<th>Path</th>
+										<th style={{ width: "1%" }}>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{channels.length === 0 ? (
+										<tr>
+											<td colSpan={3} className="text-muted text-center">
+												No channels configured yet.
+											</td>
+										</tr>
+									) : (
+										channels.map((channel) => (
+											<tr key={channel.id}>
+												<td>{channel.service}</td>
+												<td className="text-break">{channel.path}</td>
+												<td className="text-nowrap">
+													<Button
+														size="sm"
+														variant="outline-primary"
+														className="me-2"
+														disabled={!isActionsEnabled || isSaving}
+														onClick={() => setEditingChannel(channel)}
+													>
+														Edit
+													</Button>
+													<Button
+														size="sm"
+														variant="outline-danger"
+														disabled={!isActionsEnabled || isSaving}
+														onClick={() => {
+															setIsSaving(true);
+															setActionError(null);
+															void notifications
+																.removeNotificationChannel(channel.id)
+																.then(() =>
+																	setChannels((prev) =>
+																		prev.filter((entry) => entry.id !== channel.id),
+																	),
+																)
+																.catch((error) =>
+																	setActionError(
+																		error instanceof Error
+																			? error.message
+																			: String(error),
+																	),
+																)
+																.finally(() => setIsSaving(false));
+														}}
+													>
+														Delete
+													</Button>
+												</td>
+											</tr>
+										))
+									)}
+								</tbody>
+							</Table>
+						</div>
+					</div>
+				</Col>
+
+				<Col lg={7}>
+					<div className="border rounded p-3 bg-white">
+						<div className="d-flex align-items-center justify-content-between mb-2">
+							<div className="fw-semibold">Transcript Subscriptions</div>
+							<Badge bg="secondary">{subscriptions.length}</Badge>
+						</div>
+
+						<div className="border rounded p-2 mb-3 bg-body-tertiary">
+							<div className="fw-semibold mb-2">Create Alert From Saved Search</div>
+							<Row className="g-2 align-items-end">
+								<Col>
+									<Form.Label>Saved Search</Form.Label>
+									<Form.Select
+										value={selectedSavedSearchId}
+										disabled={auth.status !== "authenticated" || isSaving}
+										onChange={(event) => setSelectedSavedSearchId(event.target.value)}
+									>
+										<option value="">Select a saved search…</option>
+										{savedSearches.map((entry) => (
+											<option key={entry.id} value={entry.id}>
+												{entry.name}
+											</option>
+										))}
+									</Form.Select>
+								</Col>
+								<Col xs="auto">
+									<Button
+										type="button"
+										variant="outline-primary"
+										disabled={
+											!isActionsEnabled ||
+											isSaving ||
+											!selectedSavedSearch ||
+											talkgroups.length === 0
+										}
+										onClick={() => {
+											if (!selectedSavedSearch) {
+												return;
+											}
+
+											const derivedTopic = deriveTopicFromSearchState(
+												selectedSavedSearch.state,
+												talkgroups,
+											);
+											setSubscriptionForm((prev) => ({
+												...prev,
+												name: selectedSavedSearch.name,
+												topic: derivedTopic ?? prev.topic,
+												keywordsCsv: selectedSavedSearch.state.query ?? prev.keywordsCsv,
+											}));
+										}}
+									>
+										Prefill
+									</Button>
+								</Col>
+							</Row>
+							{selectedSavedSearch ? (
+								<div className="small text-muted mt-2">
+									{describeTranscriptSavedSearchState(selectedSavedSearch.state).length === 0
+										? "This saved search has no active filters."
+										: describeTranscriptSavedSearchState(selectedSavedSearch.state).join(" · ")}
+								</div>
+							) : null}
+							{talkgroups.length === 0 ? (
+								<div className="small text-muted mt-2">
+									Talkgroup metadata is unavailable, so we can’t derive topics from search
+									state yet.
+								</div>
+							) : null}
+						</div>
+
+						<Form
+							onSubmit={(event) => {
+								event.preventDefault();
+								if (!isActionsEnabled) {
+									return;
+								}
+
+								const payload: CreateTranscriptSubscriptionInput = {
+									name: subscriptionForm.name,
+									enabled: subscriptionForm.enabled,
+									topic: subscriptionForm.topic,
+									keywords: subscriptionForm.keywordsCsv
+										? parseCsv(subscriptionForm.keywordsCsv)
+										: undefined,
+									ignoreKeywords: subscriptionForm.ignoreKeywordsCsv
+										? parseCsv(subscriptionForm.ignoreKeywordsCsv)
+										: undefined,
+									notificationChannelIds: subscriptionForm.notificationChannelIds,
+								};
+
+								setIsSaving(true);
+								setActionError(null);
+								void notifications
+									.createTranscriptSubscription(payload)
+									.then((created) => {
+										setSubscriptions((prev) => [...prev, created]);
+										setSubscriptionForm((prev) => ({
+											...prev,
+											name: "",
+											topic: "",
+											keywordsCsv: "",
+											ignoreKeywordsCsv: "",
+										}));
+									})
+									.catch((error) => {
+										setActionError(
+											error instanceof Error ? error.message : String(error),
+										);
+									})
+									.finally(() => setIsSaving(false));
+							}}
+						>
+							<Row className="g-2">
+								<Col md={6}>
+									<Form.Label>Name</Form.Label>
+									<Form.Control
+										disabled={!isActionsEnabled || isSaving}
+										value={subscriptionForm.name}
+										onChange={(event) =>
+											setSubscriptionForm((prev) => ({
+												...prev,
+												name: event.target.value,
+											}))
+										}
+										placeholder="e.g. Night OEMC hits"
+									/>
+								</Col>
+								<Col md={3}>
+									<Form.Label>Enabled</Form.Label>
+									<Form.Check
+										type="switch"
+										disabled={!isActionsEnabled || isSaving}
+										checked={subscriptionForm.enabled}
+										onChange={(event) =>
+											setSubscriptionForm((prev) => ({
+												...prev,
+												enabled: event.target.checked,
+											}))
+										}
+										label={subscriptionForm.enabled ? "On" : "Off"}
+									/>
+								</Col>
+								<Col md={3}>
+									<Form.Label>Destinations</Form.Label>
+									<Form.Select
+										disabled={!isActionsEnabled || isSaving}
+										multiple
+										value={subscriptionForm.notificationChannelIds}
+										onChange={(event) => {
+											const selected = Array.from(event.target.selectedOptions).map(
+												(option) => option.value,
+											);
+											setSubscriptionForm((prev) => ({
+												...prev,
+												notificationChannelIds: selected,
+											}));
+										}}
+									>
+										{channels.map((channel) => (
+											<option key={channel.id} value={channel.id}>
+												{channel.service}: {channel.path}
+											</option>
+										))}
+									</Form.Select>
+									<div className="small text-muted">
+										Hold Ctrl/Cmd to pick multiple channels.
+									</div>
+								</Col>
+							</Row>
+
+							<Row className="g-2 mt-1">
+								<Col>
+									<Form.Label>Topic (talkgroup@system or regex)</Form.Label>
+									<Form.Control
+										disabled={!isActionsEnabled || isSaving}
+										value={subscriptionForm.topic}
+										onChange={(event) =>
+											setSubscriptionForm((prev) => ({
+												...prev,
+												topic: event.target.value,
+											}))
+										}
+										placeholder="e.g. 14@chi_cpd"
+									/>
+								</Col>
+							</Row>
+
+							<Row className="g-2 mt-1">
+								<Col md={6}>
+									<Form.Label>Keywords (comma-separated)</Form.Label>
+									<Form.Control
+										disabled={!isActionsEnabled || isSaving}
+										value={subscriptionForm.keywordsCsv}
+										onChange={(event) =>
+											setSubscriptionForm((prev) => ({
+												...prev,
+												keywordsCsv: event.target.value,
+											}))
+										}
+										placeholder="e.g. shots fired, pursuit"
+									/>
+								</Col>
+								<Col md={6}>
+									<Form.Label>Ignore Keywords (comma-separated)</Form.Label>
+									<Form.Control
+										disabled={!isActionsEnabled || isSaving}
+										value={subscriptionForm.ignoreKeywordsCsv}
+										onChange={(event) =>
+											setSubscriptionForm((prev) => ({
+												...prev,
+												ignoreKeywordsCsv: event.target.value,
+											}))
+										}
+										placeholder="e.g. test, drill"
+									/>
+								</Col>
+							</Row>
+
+							<div className="mt-2 d-flex justify-content-end">
+								<Button
+									type="submit"
+									disabled={
+										!isActionsEnabled ||
+										isSaving ||
+										!subscriptionForm.name.trim() ||
+										!subscriptionForm.topic.trim() ||
+										subscriptionForm.notificationChannelIds.length === 0
+									}
+								>
+									Create Alert
+								</Button>
+							</div>
+						</Form>
+
+						<div className="mt-3">
+							<Table size="sm" responsive bordered>
+								<thead>
+									<tr>
+										<th>Name</th>
+										<th>Topic</th>
+										<th>Destinations</th>
+										<th>Enabled</th>
+										<th style={{ width: "1%" }}>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{subscriptions.length === 0 ? (
+										<tr>
+											<td colSpan={5} className="text-muted text-center">
+												No subscriptions configured yet.
+											</td>
+										</tr>
+									) : (
+										subscriptions.map((subscription) => (
+											<tr key={subscription.id}>
+												<td className="text-break">
+													<div className="fw-semibold">{subscription.name}</div>
+													{subscription.keywords.length > 0 ? (
+														<div className="small text-muted">
+															Keywords: {subscription.keywords.join(", ")}
+														</div>
+													) : null}
+													{subscription.ignoreKeywords.length > 0 ? (
+														<div className="small text-muted">
+															Ignore: {subscription.ignoreKeywords.join(", ")}
+														</div>
+													) : null}
+												</td>
+												<td className="text-break">
+													<code>{subscription.topic}</code>
+												</td>
+												<td>
+													{subscription.notificationChannelIds.length === 0 ? (
+														<span className="text-muted">None</span>
+													) : (
+														subscription.notificationChannelIds.length
+													)}
+												</td>
+												<td>{subscription.enabled ? "On" : "Off"}</td>
+												<td className="text-nowrap">
+													<Button
+														size="sm"
+														variant="outline-primary"
+														className="me-2"
+														disabled={!isActionsEnabled || isSaving}
+														onClick={() => setEditingSubscription(subscription)}
+													>
+														Edit
+													</Button>
+													<Button
+														size="sm"
+														variant="outline-secondary"
+														className="me-2"
+														disabled={!isActionsEnabled || isSaving}
+														onClick={() => {
+															setIsSaving(true);
+															setActionError(null);
+															void notifications
+																.updateTranscriptSubscription(subscription.id, {
+																	enabled: !subscription.enabled,
+																})
+																.then((updated) =>
+																	setSubscriptions((prev) =>
+																		prev.map((entry) =>
+																			entry.id === subscription.id ? updated : entry,
+																		),
+																	),
+																)
+																.catch((error) =>
+																	setActionError(
+																		error instanceof Error
+																			? error.message
+																			: String(error),
+																	),
+																)
+																.finally(() => setIsSaving(false));
+														}}
+													>
+														Toggle
+													</Button>
+													<Button
+														size="sm"
+														variant="outline-danger"
+														disabled={!isActionsEnabled || isSaving}
+														onClick={() => {
+															setIsSaving(true);
+															setActionError(null);
+															void notifications
+																.removeTranscriptSubscription(subscription.id)
+																.then(() =>
+																	setSubscriptions((prev) =>
+																		prev.filter((entry) => entry.id !== subscription.id),
+																	),
+																)
+																.catch((error) =>
+																	setActionError(
+																		error instanceof Error
+																			? error.message
+																			: String(error),
+																	),
+																)
+																.finally(() => setIsSaving(false));
+														}}
+													>
+														Delete
+													</Button>
+												</td>
+											</tr>
+										))
+									)}
+								</tbody>
+							</Table>
+						</div>
+					</div>
+				</Col>
+			</Row>
+
+			<Modal show={Boolean(editingChannel)} onHide={() => setEditingChannel(null)}>
+				<Modal.Header closeButton>
+					<Modal.Title>Edit Channel</Modal.Title>
+				</Modal.Header>
+				{editingChannel ? (
+					<EditChannelForm
+						channel={editingChannel}
+						disabled={!isActionsEnabled || isSaving}
+						onCancel={() => setEditingChannel(null)}
+						onSave={(patch) => {
+							setIsSaving(true);
+							setActionError(null);
+							void notifications
+								.updateNotificationChannel(editingChannel.id, patch)
+								.then((updated) => {
+									setChannels((prev) =>
+										prev.map((entry) =>
+											entry.id === updated.id ? updated : entry,
+										),
+									);
+									setEditingChannel(null);
+								})
+								.catch((error) =>
+									setActionError(
+										error instanceof Error ? error.message : String(error),
+									),
+								)
+								.finally(() => setIsSaving(false));
+						}}
+					/>
+				) : null}
+			</Modal>
+
+			<Modal
+				show={Boolean(editingSubscription)}
+				onHide={() => setEditingSubscription(null)}
+				size="lg"
+			>
+				<Modal.Header closeButton>
+					<Modal.Title>Edit Subscription</Modal.Title>
+				</Modal.Header>
+				{editingSubscription ? (
+					<EditSubscriptionForm
+						subscription={editingSubscription}
+						channels={channels}
+						disabled={!isActionsEnabled || isSaving}
+						onCancel={() => setEditingSubscription(null)}
+						onSave={(patch) => {
+							setIsSaving(true);
+							setActionError(null);
+							void notifications
+								.updateTranscriptSubscription(editingSubscription.id, patch)
+								.then((updated) => {
+									setSubscriptions((prev) =>
+										prev.map((entry) =>
+											entry.id === updated.id ? updated : entry,
+										),
+									);
+									setEditingSubscription(null);
+								})
+								.catch((error) =>
+									setActionError(
+										error instanceof Error ? error.message : String(error),
+									),
+								)
+								.finally(() => setIsSaving(false));
+						}}
+					/>
+				) : null}
+			</Modal>
+		</div>
+	);
+}
+
+function EditChannelForm({
+	channel,
+	disabled,
+	onSave,
+	onCancel,
+}: {
+	channel: NotificationChannel;
+	disabled: boolean;
+	onSave: (patch: UpdateNotificationChannelInput) => void;
+	onCancel: () => void;
+}) {
+	const [service, setService] = useState(channel.service);
+	const [path, setPath] = useState(channel.path);
+
+	return (
+		<Form
+			onSubmit={(event) => {
+				event.preventDefault();
+				onSave({
+					service,
+					path,
+				});
+			}}
+		>
+			<Modal.Body>
+				<Row className="g-2">
+					<Col md={4}>
+						<Form.Label>Service</Form.Label>
+						<Form.Control
+							value={service}
+							disabled={disabled}
+							onChange={(event) => setService(event.target.value)}
+						/>
+					</Col>
+					<Col md={8}>
+						<Form.Label>Path</Form.Label>
+						<Form.Control
+							value={path}
+							disabled={disabled}
+							onChange={(event) => setPath(event.target.value)}
+						/>
+					</Col>
+				</Row>
+			</Modal.Body>
+			<Modal.Footer>
+				<Button type="button" variant="outline-secondary" onClick={onCancel}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={disabled || !service.trim() || !path.trim()}>
+					Save
+				</Button>
+			</Modal.Footer>
+		</Form>
+	);
+}
+
+function EditSubscriptionForm({
+	subscription,
+	channels,
+	disabled,
+	onSave,
+	onCancel,
+}: {
+	subscription: TranscriptSubscription;
+	channels: NotificationChannel[];
+	disabled: boolean;
+	onSave: (patch: UpdateTranscriptSubscriptionInput) => void;
+	onCancel: () => void;
+}) {
+	const [name, setName] = useState(subscription.name);
+	const [topic, setTopic] = useState(subscription.topic);
+	const [enabled, setEnabled] = useState(subscription.enabled);
+	const [destinationIds, setDestinationIds] = useState<string[]>(
+		subscription.notificationChannelIds,
+	);
+
+	const isValid = Boolean(name.trim() && topic.trim() && destinationIds.length > 0);
+
+	return (
+		<Form
+			onSubmit={(event) => {
+				event.preventDefault();
+				if (!isValid) {
+					return;
+				}
+
+				onSave({
+					name,
+					topic,
+					enabled,
+					notificationChannelIds: destinationIds,
+				});
+			}}
+		>
+			<Modal.Body>
+				<Row className="g-2">
+					<Col md={6}>
+						<Form.Label>Name</Form.Label>
+						<Form.Control
+							value={name}
+							disabled={disabled}
+							onChange={(event) => setName(event.target.value)}
+						/>
+					</Col>
+					<Col md={3}>
+						<Form.Label>Enabled</Form.Label>
+						<Form.Check
+							type="switch"
+							checked={enabled}
+							disabled={disabled}
+							onChange={(event) => setEnabled(event.target.checked)}
+							label={enabled ? "On" : "Off"}
+						/>
+					</Col>
+					<Col md={3}>
+						<Form.Label>Destinations</Form.Label>
+						<Form.Select
+							disabled={disabled}
+							multiple
+							value={destinationIds}
+							onChange={(event) => {
+								const selected = Array.from(event.target.selectedOptions).map(
+									(option) => option.value,
+								);
+								setDestinationIds(selected);
+							}}
+						>
+							{channels.map((channel) => (
+								<option key={channel.id} value={channel.id}>
+									{channel.service}: {channel.path}
+								</option>
+							))}
+						</Form.Select>
+					</Col>
+				</Row>
+
+				<Row className="g-2 mt-1">
+					<Col>
+						<Form.Label>Topic</Form.Label>
+						<Form.Control
+							value={topic}
+							disabled={disabled}
+							onChange={(event) => setTopic(event.target.value)}
+						/>
+						<div className="small text-muted">
+							Keyword and location filters are set at creation time today.
+						</div>
+					</Col>
+				</Row>
+			</Modal.Body>
+			<Modal.Footer>
+				<Button type="button" variant="outline-secondary" onClick={onCancel}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={disabled || !isValid}>
+					Save
+				</Button>
+			</Modal.Footer>
+		</Form>
+	);
+}
+

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -15,6 +15,10 @@ export default function Header() {
         <div className="px-2 fw-bold">
           <Link to="/map">Transcript Map</Link>
         </div>
+
+        <div className="px-2 fw-bold">
+          <Link to="/alerts">Alerts</Link>
+        </div>
       </nav>
     </header>
   )

--- a/frontend/src/providers/notifications.tsx
+++ b/frontend/src/providers/notifications.tsx
@@ -2,17 +2,670 @@ import { createContext, useContext, type ReactNode } from "react";
 
 export type NotificationLevel = "info" | "success" | "warning" | "error";
 
+export type NotificationChannel = {
+	id: string;
+	service: string;
+	path: string;
+	createdAt?: string;
+	updatedAt?: string;
+};
+
+export type TranscriptSubscriptionLocation = {
+	address?: string;
+	radius?: number;
+	travelTime?: number;
+	geo?: {
+		lat: number;
+		lng: number;
+	};
+};
+
+export type TranscriptSubscription = {
+	id: string;
+	name: string;
+	enabled: boolean;
+	topic: string;
+	keywords: string[];
+	ignoreKeywords: string[];
+	location: TranscriptSubscriptionLocation | null;
+	notificationChannelIds: string[];
+	createdAt?: string;
+	updatedAt?: string;
+};
+
+export type AvailableTalkgroup = {
+	id: number;
+	label: string;
+	system: string;
+	value: string;
+};
+
+export type AvailableTalkgroupGroup = {
+	id: number;
+	group: string;
+	talkgroups: AvailableTalkgroup[];
+};
+
+export type AvailableTalkgroupSystem = {
+	id: number;
+	group: string;
+	talkgroups: AvailableTalkgroupGroup[];
+};
+
+export type CreateNotificationChannelInput = {
+	service: string;
+	path: string;
+};
+
+export type UpdateNotificationChannelInput = Partial<CreateNotificationChannelInput>;
+
+export type CreateTranscriptSubscriptionInput = {
+	name: string;
+	enabled: boolean;
+	topic: string;
+	keywords?: string[];
+	ignoreKeywords?: string[];
+	location?: TranscriptSubscriptionLocation | null;
+	notificationChannelIds: string[];
+};
+
+export type UpdateTranscriptSubscriptionInput = Partial<CreateTranscriptSubscriptionInput>;
+
 export type NotificationStore = {
 	notify: (level: NotificationLevel, message: string) => void;
+	listNotificationChannels: () => Promise<NotificationChannel[]>;
+	createNotificationChannel: (
+		input: CreateNotificationChannelInput,
+	) => Promise<NotificationChannel>;
+	updateNotificationChannel: (
+		id: string,
+		input: UpdateNotificationChannelInput,
+	) => Promise<NotificationChannel>;
+	removeNotificationChannel: (id: string) => Promise<void>;
+	listTranscriptSubscriptions: () => Promise<TranscriptSubscription[]>;
+	createTranscriptSubscription: (
+		input: CreateTranscriptSubscriptionInput,
+	) => Promise<TranscriptSubscription>;
+	updateTranscriptSubscription: (
+		id: string,
+		input: UpdateTranscriptSubscriptionInput,
+	) => Promise<TranscriptSubscription>;
+	removeTranscriptSubscription: (id: string) => Promise<void>;
+	listAvailableTalkgroups: () => Promise<AvailableTalkgroupSystem[]>;
 };
 
-const defaultNotificationStore: NotificationStore = {
-	notify: () => {},
-};
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-const NotificationContext = createContext<NotificationStore>(
-	defaultNotificationStore,
-);
+function trimTrailingSlash(value: string): string {
+	return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function getXsrfToken(): string | null {
+	if (typeof document === "undefined") {
+		return null;
+	}
+
+	const tokenCookie = document.cookie
+		.split("; ")
+		.find((row) => row.startsWith("XSRF-TOKEN="))
+		?.split("=")[1];
+
+	return tokenCookie ? decodeURIComponent(tokenCookie) : null;
+}
+
+async function readSirensJson(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("Content-Type") || "";
+	if (contentType.includes("application/json")) {
+		return response.json();
+	}
+	return response.text();
+}
+
+function parseStringArray(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value
+			.map((item) => (typeof item === "string" ? item.trim() : ""))
+			.filter(Boolean);
+	}
+
+	if (typeof value === "string" && value.trim()) {
+		try {
+			const parsed = JSON.parse(value);
+			return parseStringArray(parsed);
+		} catch {
+			return [value.trim()];
+		}
+	}
+
+	return [];
+}
+
+function parseLocation(
+	value: unknown,
+): TranscriptSubscriptionLocation | null {
+	if (!value) {
+		return null;
+	}
+
+	if (typeof value === "string") {
+		try {
+			return parseLocation(JSON.parse(value));
+		} catch {
+			return null;
+		}
+	}
+
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	const address = typeof value.address === "string" ? value.address : undefined;
+	const radius = typeof value.radius === "number" ? value.radius : undefined;
+	const travelTime =
+		typeof value.travel_time === "number"
+			? value.travel_time
+			: typeof value.travelTime === "number"
+				? value.travelTime
+				: undefined;
+	const geoCandidate = value.geo;
+	const geo =
+		isRecord(geoCandidate) &&
+		typeof geoCandidate.lat === "number" &&
+		typeof geoCandidate.lng === "number"
+			? { lat: geoCandidate.lat, lng: geoCandidate.lng }
+			: null;
+
+	return {
+		...(address ? { address } : {}),
+		...(radius !== undefined ? { radius } : {}),
+		...(travelTime !== undefined ? { travelTime } : {}),
+		...(geo ? { geo } : {}),
+	};
+}
+
+function parseNotificationChannel(value: unknown): NotificationChannel | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	const id = value.id;
+	const service = value.service;
+	const path = value.path;
+	if (
+		(typeof id !== "number" && typeof id !== "string") ||
+		typeof service !== "string" ||
+		typeof path !== "string"
+	) {
+		return null;
+	}
+
+	const createdAt =
+		typeof value.created_at === "string"
+			? value.created_at
+			: typeof value.createdAt === "string"
+				? value.createdAt
+				: undefined;
+	const updatedAt =
+		typeof value.updated_at === "string"
+			? value.updated_at
+			: typeof value.updatedAt === "string"
+				? value.updatedAt
+				: undefined;
+
+	return {
+		id: String(id),
+		service,
+		path,
+		...(createdAt ? { createdAt } : {}),
+		...(updatedAt ? { updatedAt } : {}),
+	};
+}
+
+function parseTranscriptSubscription(
+	value: unknown,
+): TranscriptSubscription | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	const id = value.id;
+	const name = value.name;
+	const topic = value.topic;
+	const enabled =
+		typeof value.enabled === "boolean"
+			? value.enabled
+			: typeof value.enabled === "number"
+				? value.enabled > 0
+				: true;
+
+	if (
+		(typeof id !== "number" && typeof id !== "string") ||
+		typeof name !== "string" ||
+		typeof topic !== "string"
+	) {
+		return null;
+	}
+
+	const createdAt =
+		typeof value.created_at === "string"
+			? value.created_at
+			: typeof value.createdAt === "string"
+				? value.createdAt
+				: undefined;
+	const updatedAt =
+		typeof value.updated_at === "string"
+			? value.updated_at
+			: typeof value.updatedAt === "string"
+				? value.updatedAt
+				: undefined;
+
+	const notificationChannelIds = parseStringArray(
+		value.notification_channels ?? value.notificationChannelIds,
+	).map(String);
+
+	return {
+		id: String(id),
+		name: name.trim(),
+		enabled,
+		topic: topic.trim(),
+		keywords: parseStringArray(value.keywords),
+		ignoreKeywords: parseStringArray(
+			value.ignore_keywords ?? value.ignoreKeywords,
+		),
+		location: parseLocation(value.location),
+		notificationChannelIds,
+		...(createdAt ? { createdAt } : {}),
+		...(updatedAt ? { updatedAt } : {}),
+	};
+}
+
+function parseAvailableTalkgroups(
+	value: unknown,
+): AvailableTalkgroupSystem[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	return value
+		.map((system) => {
+			if (!isRecord(system)) {
+				return null;
+			}
+
+			const id = system.id;
+			const group = system.group;
+			const talkgroups = system.talkgroups;
+			if (typeof id !== "number" || typeof group !== "string" || !Array.isArray(talkgroups)) {
+				return null;
+			}
+
+			const parsedGroups = talkgroups
+				.map((groupValue) => {
+					if (!isRecord(groupValue)) {
+						return null;
+					}
+
+					const groupId = groupValue.id;
+					const groupName = groupValue.group;
+					const groupTalkgroups = groupValue.talkgroups;
+					if (
+						typeof groupId !== "number" ||
+						typeof groupName !== "string" ||
+						!Array.isArray(groupTalkgroups)
+					) {
+						return null;
+					}
+
+					const parsedTalkgroups = groupTalkgroups
+						.map((tg) => {
+							if (!isRecord(tg)) {
+								return null;
+							}
+
+							const tgId = tg.id;
+							const label = tg.label;
+							const systemName = tg.system;
+							const tgValue = tg.value;
+							if (
+								typeof tgId !== "number" ||
+								typeof label !== "string" ||
+								typeof systemName !== "string" ||
+								typeof tgValue !== "string"
+							) {
+								return null;
+							}
+
+							return {
+								id: tgId,
+								label,
+								system: systemName,
+								value: tgValue,
+							} satisfies AvailableTalkgroup;
+						})
+						.filter((tg): tg is AvailableTalkgroup => tg !== null);
+
+					return {
+						id: groupId,
+						group: groupName,
+						talkgroups: parsedTalkgroups,
+					} satisfies AvailableTalkgroupGroup;
+				})
+				.filter((entry): entry is AvailableTalkgroupGroup => entry !== null);
+
+			return {
+				id,
+				group,
+				talkgroups: parsedGroups,
+			} satisfies AvailableTalkgroupSystem;
+		})
+		.filter((system): system is AvailableTalkgroupSystem => system !== null);
+}
+
+function createNoopNotificationStore(): NotificationStore {
+	return {
+		notify: () => {},
+		async listNotificationChannels() {
+			return [];
+		},
+		async createNotificationChannel() {
+			throw new Error("Notification channels are not configured for this app.");
+		},
+		async updateNotificationChannel() {
+			throw new Error("Notification channels are not configured for this app.");
+		},
+		async removeNotificationChannel() {
+			throw new Error("Notification channels are not configured for this app.");
+		},
+		async listTranscriptSubscriptions() {
+			return [];
+		},
+		async createTranscriptSubscription() {
+			throw new Error("Transcript subscriptions are not configured for this app.");
+		},
+		async updateTranscriptSubscription() {
+			throw new Error("Transcript subscriptions are not configured for this app.");
+		},
+		async removeTranscriptSubscription() {
+			throw new Error("Transcript subscriptions are not configured for this app.");
+		},
+		async listAvailableTalkgroups() {
+			return [];
+		},
+	};
+}
+
+export function createSirensBackendNotificationStore({
+	apiBaseUrl,
+}: {
+	apiBaseUrl: string;
+}): NotificationStore {
+	const baseUrl = trimTrailingSlash(apiBaseUrl);
+
+	return {
+		notify: () => {},
+
+		async listNotificationChannels() {
+			const response = await fetch(`${baseUrl}/api/notificationChannels`, {
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+				},
+			});
+			if (!response.ok) {
+				throw new Error(
+					`Failed to load notification channels (${response.status})`,
+				);
+			}
+
+			const payload = await response.json();
+			return Array.isArray(payload)
+				? payload
+						.map(parseNotificationChannel)
+						.filter((channel): channel is NotificationChannel => channel !== null)
+				: [];
+		},
+
+		async createNotificationChannel(input) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/notificationChannels`, {
+				method: "POST",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					service: input.service,
+					path: input.path,
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to create notification channel (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = await response.json();
+			const channel = parseNotificationChannel(payload);
+			if (!channel) {
+				throw new Error("Notification channel was created but could not be parsed.");
+			}
+			return channel;
+		},
+
+		async updateNotificationChannel(id, input) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/notificationChannels/${id}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					...(input.service ? { service: input.service } : {}),
+					...(input.path ? { path: input.path } : {}),
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to update notification channel (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = await response.json();
+			const channel = parseNotificationChannel(payload);
+			if (!channel) {
+				throw new Error("Notification channel was updated but could not be parsed.");
+			}
+			return channel;
+		},
+
+		async removeNotificationChannel(id) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/notificationChannels/${id}`, {
+				method: "DELETE",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to delete notification channel (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+		},
+
+		async listTranscriptSubscriptions() {
+			const response = await fetch(`${baseUrl}/api/transcriptSubscriptions`, {
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+				},
+			});
+			if (!response.ok) {
+				throw new Error(
+					`Failed to load transcript subscriptions (${response.status})`,
+				);
+			}
+
+			const payload = await response.json();
+			return Array.isArray(payload)
+				? payload
+						.map(parseTranscriptSubscription)
+						.filter(
+							(sub): sub is TranscriptSubscription => sub !== null,
+						)
+				: [];
+		},
+
+		async createTranscriptSubscription(input) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/transcriptSubscriptions`, {
+				method: "POST",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					name: input.name,
+					enabled: input.enabled,
+					topic: input.topic,
+					...(input.keywords ? { keywords: input.keywords } : {}),
+					...(input.ignoreKeywords
+						? { ignore_keywords: input.ignoreKeywords }
+						: {}),
+					...(input.location ? { location: input.location } : {}),
+					notification_channels: input.notificationChannelIds,
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to create transcript subscription (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = await response.json();
+			const subscription = parseTranscriptSubscription(payload);
+			if (!subscription) {
+				throw new Error(
+					"Transcript subscription was created but could not be parsed.",
+				);
+			}
+
+			return {
+				...subscription,
+				notificationChannelIds:
+					subscription.notificationChannelIds.length > 0
+						? subscription.notificationChannelIds
+						: input.notificationChannelIds.map(String),
+			};
+		},
+
+		async updateTranscriptSubscription(id, input) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/transcriptSubscriptions/${id}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+				body: JSON.stringify({
+					...(input.name ? { name: input.name } : {}),
+					...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+					...(input.topic ? { topic: input.topic } : {}),
+					...(input.notificationChannelIds
+						? { notification_channels: input.notificationChannelIds }
+						: {}),
+				}),
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to update transcript subscription (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+
+			const payload = await response.json();
+			const subscription = parseTranscriptSubscription(payload);
+			if (!subscription) {
+				throw new Error(
+					"Transcript subscription was updated but could not be parsed.",
+				);
+			}
+
+			return {
+				...subscription,
+				notificationChannelIds:
+					subscription.notificationChannelIds.length > 0
+						? subscription.notificationChannelIds
+						: input.notificationChannelIds?.map(String) ?? [],
+			};
+		},
+
+		async removeTranscriptSubscription(id) {
+			const xsrfToken = getXsrfToken();
+			const response = await fetch(`${baseUrl}/api/transcriptSubscriptions/${id}`, {
+				method: "DELETE",
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+					...(xsrfToken ? { "X-XSRF-TOKEN": xsrfToken } : {}),
+				},
+			});
+			if (!response.ok) {
+				const detail = await readSirensJson(response);
+				throw new Error(
+					`Failed to delete transcript subscription (${response.status}): ${JSON.stringify(detail)}`,
+				);
+			}
+		},
+
+		async listAvailableTalkgroups() {
+			const response = await fetch(`${baseUrl}/api/searchTalkgroups`, {
+				credentials: "include",
+				headers: {
+					Accept: "application/json",
+				},
+			});
+			if (!response.ok) {
+				throw new Error(
+					`Failed to load available talkgroups (${response.status})`,
+				);
+			}
+
+			const payload = await response.json();
+			return parseAvailableTalkgroups(payload);
+		},
+	};
+}
+
+const defaultNotificationStore: NotificationStore = (() => {
+	const sirensApiBaseUrl = import.meta.env.VITE_SIRENS_API_BASE_URL;
+	if (sirensApiBaseUrl) {
+		return createSirensBackendNotificationStore({
+			apiBaseUrl: sirensApiBaseUrl,
+		});
+	}
+
+	return createNoopNotificationStore();
+})();
+
+const NotificationContext = createContext<NotificationStore>(defaultNotificationStore);
 
 export function NotificationsProvider({
 	children,
@@ -31,4 +684,3 @@ export function NotificationsProvider({
 export function useNotifications(): NotificationStore {
 	return useContext(NotificationContext);
 }
-

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as MapRouteImport } from './routes/map'
 import { Route as LiveRouteImport } from './routes/live'
 import { Route as ChatRouteImport } from './routes/chat'
+import { Route as AlertsRouteImport } from './routes/alerts'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiCopilotkitRouteImport } from './routes/api/copilotkit'
 
@@ -30,6 +31,11 @@ const ChatRoute = ChatRouteImport.update({
   path: '/chat',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AlertsRoute = AlertsRouteImport.update({
+  id: '/alerts',
+  path: '/alerts',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -43,6 +49,7 @@ const ApiCopilotkitRoute = ApiCopilotkitRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/alerts': typeof AlertsRoute
   '/chat': typeof ChatRoute
   '/live': typeof LiveRoute
   '/map': typeof MapRoute
@@ -50,6 +57,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/alerts': typeof AlertsRoute
   '/chat': typeof ChatRoute
   '/live': typeof LiveRoute
   '/map': typeof MapRoute
@@ -58,6 +66,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/alerts': typeof AlertsRoute
   '/chat': typeof ChatRoute
   '/live': typeof LiveRoute
   '/map': typeof MapRoute
@@ -65,14 +74,22 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/chat' | '/live' | '/map' | '/api/copilotkit'
+  fullPaths: '/' | '/alerts' | '/chat' | '/live' | '/map' | '/api/copilotkit'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/chat' | '/live' | '/map' | '/api/copilotkit'
-  id: '__root__' | '/' | '/chat' | '/live' | '/map' | '/api/copilotkit'
+  to: '/' | '/alerts' | '/chat' | '/live' | '/map' | '/api/copilotkit'
+  id:
+    | '__root__'
+    | '/'
+    | '/alerts'
+    | '/chat'
+    | '/live'
+    | '/map'
+    | '/api/copilotkit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AlertsRoute: typeof AlertsRoute
   ChatRoute: typeof ChatRoute
   LiveRoute: typeof LiveRoute
   MapRoute: typeof MapRoute
@@ -102,6 +119,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/alerts': {
+      id: '/alerts'
+      path: '/alerts'
+      fullPath: '/alerts'
+      preLoaderRoute: typeof AlertsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -121,6 +145,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AlertsRoute: AlertsRoute,
   ChatRoute: ChatRoute,
   LiveRoute: LiveRoute,
   MapRoute: MapRoute,

--- a/frontend/src/routes/alerts.tsx
+++ b/frontend/src/routes/alerts.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import Container from "react-bootstrap/Container";
+
+import Alerts from "../components/Alerts";
+
+export const Route = createFileRoute("/alerts")({
+	component: AlertsPage,
+});
+
+function AlertsPage() {
+	return (
+		<Container fluid={true}>
+			<Alerts />
+		</Container>
+	);
+}
+


### PR DESCRIPTION
Implements `CRI-67` by wiring the shared frontend to the private Sirens notification APIs.

Changes:
- Expands `NotificationStore` into an alerting client abstraction:
  - notification channels CRUD (`/api/notificationChannels`)
  - transcript subscriptions CRUD (`/api/transcriptSubscriptions`)
  - talkgroup metadata (`/api/searchTalkgroups`) for deriving topics from saved search state
- Adds a Sirens backend adapter selected when `VITE_SIRENS_API_BASE_URL` is set (cookie auth; XSRF header for writes).
- Adds an `/alerts` page (and header link) that:
  - manages notification channels
  - manages transcript subscriptions (create/edit/toggle/delete)
  - can prefill a new alert from a saved search’s normalized state
- Keeps OSS/default behavior safe via a no-op store + entitlement gating (`canCreateAlerts`).

Local verification:
- `cd frontend && npm test`
- `cd frontend && npm run build`