### PR TITLE
Frontend: config-driven map defaults + search preset (CRI-68)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,6 +17,16 @@ To build this application for production:
 npm run build
 ```
 
+## Configuration
+
+Optional market defaults (leave unset for city-agnostic defaults):
+
+- `VITE_TRANSCRIPT_MAP_CENTER`: map center as `"lat,lng"` (example: `"41.8781,-87.6298"`).
+- `VITE_TRANSCRIPT_MAP_ZOOM`: map zoom as a number (example: `"10"`).
+- `VITE_TRANSCRIPT_MAP_BOUNDING_BOX`: initial bounds as `"south,west,north,east"` (example: `"41.45,-88.05,42.1,-87.35"`).
+- `VITE_TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES`: comma-separated `short_name` system ids used by the preset button (example: `"chi_cpd,chi_cfd,chi_oemc"`).
+- `VITE_TRANSCRIPT_SEARCH_PRESET_LABEL`: label for the preset button (example: `"Chicago only"`).
+
 ## Testing
 
 This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -61,11 +61,36 @@ function buildDefaultIndexUiState(indexName: string) {
 	};
 }
 
-function buildChicagoOnlyIndexUiState(indexName: string) {
+function parseCsvList(value: string | undefined): string[] {
+	if (!value) {
+		return [];
+	}
+
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+}
+
+const TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES = parseCsvList(
+	import.meta.env.VITE_TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES,
+);
+
+const TRANSCRIPT_SEARCH_PRESET_LABEL =
+	typeof import.meta.env.VITE_TRANSCRIPT_SEARCH_PRESET_LABEL === "string" &&
+	import.meta.env.VITE_TRANSCRIPT_SEARCH_PRESET_LABEL.trim()
+		? import.meta.env.VITE_TRANSCRIPT_SEARCH_PRESET_LABEL.trim()
+		: "Local only";
+
+function buildPresetIndexUiState(indexName: string) {
+	if (TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES.length === 0) {
+		return buildDefaultIndexUiState(indexName);
+	}
+
 	return {
 		...buildDefaultIndexUiState(indexName),
 		refinementList: {
-			short_name: ["chi_cpd", "chi_cfd", "chi_oemc"],
+			short_name: TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES,
 		},
 	};
 }
@@ -351,16 +376,18 @@ function SearchToolbarActions({ indexName }: { indexName: string }) {
 			>
 				Default filters
 			</Button>
-			<Button
-				type="button"
-				size="sm"
-				variant="outline-primary"
-				onClick={() => {
-					applyIndexUiState(buildChicagoOnlyIndexUiState(indexName));
-				}}
-			>
-				Chicago only
-			</Button>
+			{TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES.length > 0 ? (
+				<Button
+					type="button"
+					size="sm"
+					variant="outline-primary"
+					onClick={() => {
+						applyIndexUiState(buildPresetIndexUiState(indexName));
+					}}
+				>
+					{TRANSCRIPT_SEARCH_PRESET_LABEL}
+				</Button>
+			) : null}
 			<Button
 				type="button"
 				size="sm"

--- a/frontend/src/lib/transcriptGeoSearch.ts
+++ b/frontend/src/lib/transcriptGeoSearch.ts
@@ -1,12 +1,65 @@
-export const DEFAULT_TRANSCRIPT_MAP_CENTER = {
-	lat: 41.8781,
-	lng: -87.6298,
+function parseNumber(value: string | undefined): number | null {
+	if (!value) {
+		return null;
+	}
+
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseLatLng(value: string | undefined): { lat: number; lng: number } | null {
+	if (!value) {
+		return null;
+	}
+
+	const [latRaw, lngRaw] = value.split(",", 2).map((part) => part.trim());
+	const lat = parseNumber(latRaw);
+	const lng = parseNumber(lngRaw);
+	if (lat === null || lng === null) {
+		return null;
+	}
+
+	return { lat, lng };
+}
+
+function parseBoundingBox(value: string | undefined): string | null {
+	if (!value) {
+		return null;
+	}
+
+	const parts = value.split(",").map((part) => part.trim());
+	if (parts.length !== 4) {
+		return null;
+	}
+
+	const numeric = parts.map((part) => parseNumber(part));
+	if (numeric.some((entry) => entry === null)) {
+		return null;
+	}
+
+	return numeric.join(",");
+}
+
+const DEFAULT_CENTER_FALLBACK = {
+	lat: 39.8283,
+	lng: -98.5795,
 };
 
-export const DEFAULT_TRANSCRIPT_MAP_ZOOM = 10;
+const DEFAULT_ZOOM_FALLBACK = 4;
+
+const DEFAULT_BOUNDING_BOX_FALLBACK =
+	"24.396308,-124.848974,49.384358,-66.885444";
+
+export const DEFAULT_TRANSCRIPT_MAP_CENTER =
+	parseLatLng(import.meta.env.VITE_TRANSCRIPT_MAP_CENTER) ??
+	DEFAULT_CENTER_FALLBACK;
+
+export const DEFAULT_TRANSCRIPT_MAP_ZOOM =
+	parseNumber(import.meta.env.VITE_TRANSCRIPT_MAP_ZOOM) ?? DEFAULT_ZOOM_FALLBACK;
 
 export const DEFAULT_TRANSCRIPT_MAP_BOUNDING_BOX =
-	"41.45,-88.05,42.1,-87.35";
+	parseBoundingBox(import.meta.env.VITE_TRANSCRIPT_MAP_BOUNDING_BOX) ??
+	DEFAULT_BOUNDING_BOX_FALLBACK;
 
 export interface TranscriptBoundsLike {
 	getSouth: () => number;


### PR DESCRIPTION
Implements `CRI-68` groundwork by making Chicago-specific defaults optional and configuration-driven.

Changes:
- Map defaults are now driven by env (with city-agnostic fallbacks):
  - `VITE_TRANSCRIPT_MAP_CENTER` ("lat,lng")
  - `VITE_TRANSCRIPT_MAP_ZOOM`
  - `VITE_TRANSCRIPT_MAP_BOUNDING_BOX` ("south,west,north,east")
- Replaces the hardcoded “Chicago only” preset with an optional preset button:
  - `VITE_TRANSCRIPT_SEARCH_PRESET_SHORT_NAMES` (comma-separated `short_name` ids)
  - `VITE_TRANSCRIPT_SEARCH_PRESET_LABEL`
- Documents these env vars in `frontend/README.md`.

Local verification: `cd frontend && npm test`.