### PR TITLE
[codex] Restart unhealthy Celery workers

### DIFF
--- a/docker-compose.worker-api.yml
+++ b/docker-compose.worker-api.yml
@@ -13,6 +13,7 @@ services:
       - ./backend/pyproject.toml:/src/backend/pyproject.toml
       - ./config:/src/config
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
       - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=vendor;provider=openai;model=whisper-1}
       - TRANSCRIPTION_PROFILE=${TRANSCRIPTION_PROFILE:-kind=vendor;provider=openai;model=whisper-1}
@@ -27,4 +28,10 @@ services:
       - CELERY_CONCURRENCY
       - CELERY_PREFETCH_MULTIPLIER
     env_file: .env
+    healthcheck:
+      test: ["CMD", "celery-healthcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 1
+      start_period: 60s
     restart: always

--- a/docker-compose.worker-qwen.yml
+++ b/docker-compose.worker-qwen.yml
@@ -13,6 +13,7 @@ services:
       - ./backend/pyproject.toml:/src/backend/pyproject.toml
       - ./config:/src/config
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
       - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25}
       - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25
@@ -30,6 +31,12 @@ services:
     depends_on:
       asr-qwen:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "celery-healthcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 1
+      start_period: 60s
     restart: always
 
   asr-qwen:

--- a/docker-compose.worker-voxtral.yml
+++ b/docker-compose.worker-voxtral.yml
@@ -13,6 +13,7 @@ services:
       - ./backend/pyproject.toml:/src/backend/pyproject.toml
       - ./config:/src/config
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
       - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602}
       - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602
@@ -29,6 +30,12 @@ services:
     env_file: .env
     depends_on:
       - asr-voxtral
+    healthcheck:
+      test: ["CMD", "celery-healthcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 1
+      start_period: 60s
     restart: always
 
   asr-voxtral:

--- a/docker-compose.worker-whisper.yml
+++ b/docker-compose.worker-whisper.yml
@@ -13,6 +13,7 @@ services:
       - ./backend/pyproject.toml:/src/backend/pyproject.toml
       - ./config:/src/config
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
       - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3}
       - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
@@ -30,6 +31,12 @@ services:
     depends_on:
       asr-whisper:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "celery-healthcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 1
+      start_period: 60s
     restart: always
 
   asr-whisper:

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -13,7 +13,14 @@ services:
       - ./backend/pyproject.toml:/src/backend/pyproject.toml
       - ./config:/src/config
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
       - CELERY_QUEUES=post_transcribe
     env_file: .env
+    healthcheck:
+      test: ["CMD", "celery-healthcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 1
+      start_period: 60s
     restart: always

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY backend/alembic.ini backend/alembic.ini
 COPY backend/app backend/app
 COPY config config
-COPY docker/docker-entrypoint.sh /usr/local/bin/
+COPY docker/docker-entrypoint.sh docker/celery-healthcheck.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/celery-healthcheck.sh
 
 ENV PYTHONPATH=/src/backend
 

--- a/docker/celery-healthcheck.sh
+++ b/docker/celery-healthcheck.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+shutdown_container() {
+    echo "Celery worker healthcheck failed; stopping container for restart" >&2
+    kill -s 15 1
+    sleep "${CELERY_HEALTHCHECK_SHUTDOWN_GRACE_SECONDS:-10}"
+    kill -s 9 1
+}
+
+expand_celery_hostname() {
+    local value="$1"
+    local full_hostname
+    local short_hostname
+    local domain
+
+    full_hostname="$(hostname -f 2>/dev/null || hostname)"
+    short_hostname="$(hostname -s 2>/dev/null || hostname)"
+    domain="${full_hostname#"$short_hostname"}"
+    domain="${domain#.}"
+
+    value="${value//%h/$full_hostname}"
+    value="${value//%n/$short_hostname}"
+    value="${value//%d/$domain}"
+
+    printf '%s' "$value"
+}
+
+celery_hostname="${CELERY_HOSTNAME-}"
+if [ -z "$celery_hostname" ]; then
+    celery_hostname="celery"
+    if [ -n "${GIT_COMMIT-}" ]; then
+        celery_hostname="${celery_hostname}-${GIT_COMMIT::7}"
+    fi
+    if [ -f /root/.vast_containerlabel ]; then
+        celery_hostname="$celery_hostname@$(cat /root/.vast_containerlabel)"
+    else
+        celery_hostname="$celery_hostname@%n"
+    fi
+fi
+
+celery_destination="$(expand_celery_hostname "$celery_hostname")"
+timeout_seconds="${CELERY_HEALTHCHECK_TIMEOUT_SECONDS:-10}"
+
+if uv run --directory backend celery --app=app.worker.celery inspect \
+    --timeout "$timeout_seconds" \
+    --destination "$celery_destination" \
+    ping >/tmp/celery-healthcheck.out 2>/tmp/celery-healthcheck.err; then
+    exit 0
+fi
+
+cat /tmp/celery-healthcheck.out >&2 || true
+cat /tmp/celery-healthcheck.err >&2 || true
+shutdown_container


### PR DESCRIPTION
## Summary

Adds a dedicated Celery worker healthcheck that targets the local worker node with `celery inspect ping`. When the worker process is alive but no longer responding, the healthcheck terminates PID 1 so Docker's existing `restart: always` policy recreates the container.

The healthcheck is included in the built image and mounted into each local worker compose stack, including the Qwen worker.

## Validation

- `bash -n docker/celery-healthcheck.sh`
- `docker compose -f docker-compose.worker.yml config --services`
- `docker compose -f docker-compose.worker-api.yml config --services`
- `docker compose -f docker-compose.worker-whisper.yml config --services`
- `docker compose -f docker-compose.worker-qwen.yml config --services`
- `docker compose -f docker-compose.worker-voxtral.yml config --services`