### PR TITLE
[codex] Use model keys for transcription queues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,17 +17,18 @@ COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.
 #
 
 # Used when an API request does not explicitly set transcription_profile.
-DEFAULT_TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+DEFAULT_TRANSCRIPTION_PROFILE=kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
 
 # Worker-specific compose files set these automatically.
-# TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
-# CELERY_QUEUES=transcribe.remote.pool.local.whisper.large-v3
+# TRANSCRIPTION_PROFILE=kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+# CELERY_QUEUES=transcribe.model.whisper-large-v3
 
 # Generic ASR API settings for workers that call a sibling or remote OpenAI-compatible transcription service.
 # Whisper defaults to speaches on http://asr-whisper:8000/v1.
 # ASR_API_URL=http://asr-whisper:8000/v1
 # ASR_ROUTER_URL=http://asr-router:8001/v1
 # ASR_PROVIDER=speaches
+# ASR_MODEL_KEY=whisper-large-v3
 # ASR_VARIANT=large-v3
 # ASR_MODEL=Systran/faster-distil-whisper-small.en
 # ASR_WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:latest-cuda
@@ -39,9 +40,9 @@ DEFAULT_TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=la
 
 # Structured pool and vendor routing strings can be passed to API routes as `transcription_profile`.
 # Examples:
-# kind=vendor;provider=openai;model=whisper-1
-# kind=vendor;provider=deepinfra;model=openai/whisper-large-v3-turbo
-# kind=pool;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+# kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1
+# kind=vendor;model_key=whisper-large-v3-turbo;provider=deepinfra;model=openai/whisper-large-v3-turbo
+# kind=pool;model_key=whisper-large-v3;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
 
 # Legacy compatibility only. Prefer TRANSCRIPTION_PROFILE instead.
 WHISPER_IMPLEMENTATION=whisper-asr-api
@@ -74,9 +75,9 @@ CELERY_RESULT_BACKEND=rpc://rabbitmq:5672
 FLOWER_BROKER_API=http://rabbitmq:15672/api/
 
 # Vast autoscaling
-# AUTOSCALE_TRANSCRIPTION_PROFILE=kind=pool;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+# AUTOSCALE_TRANSCRIPTION_PROFILE=kind=pool;model_key=whisper-large-v3;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
 # AUTOSCALE_ASR_POOL=vast.whisper.large-v3
-# AUTOSCALE_QUEUE_NAME=transcribe.remote.pool.vast.whisper.large-v3
+# AUTOSCALE_QUEUE_NAME=transcribe.model.whisper-large-v3
 # AUTOSCALE_TEMPLATE_HASH=
 # AUTOSCALE_INSTANCE_IMAGE=ghcr.io/crimeisdown/trunk-transcribe:main-whisper-large-v3-cuda_12.1.0
 # AUTOSCALE_MIN_INSTANCES=1

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This is experimental alpha-version software, use at your own risk. Expect breaki
 ## Architecture
 
 1. `transcribe.sh` runs from trunk-recorder which makes a POST request to the API, passing along the call WAV and JSON
-1. API resolves a structured `transcription_profile` for the request and adds the transcription job to the matching RabbitMQ queue
-1. A worker stack consumes one queue per operational profile, for example `transcribe.remote.vendor`, `transcribe.remote.pool.local.whisper.large-v3`, or `transcribe.remote.pool.vast.whisper.large-v3`
+1. API resolves a structured `transcription_profile` for the request and adds the transcription job to the RabbitMQ queue for that profile's `model_key`
+1. A worker stack consumes one queue per transcription model, for example `transcribe.model.whisper-1`, `transcribe.model.whisper-large-v3`, or `transcribe.model.qwen-p25`
 1. Every worker uses the same OpenAI-compatible transcription contract: send audio to `POST /v1/audio/transcriptions`, receive verbose JSON back, and normalize that into the shared transcript shape
 1. The `post_transcribe` worker stores the results in search and sends notifications
 
@@ -66,10 +66,10 @@ There are numerous `docker-compose.*.yml` files in this repo for various configu
 
 Each transcription machine should run exactly one profile-specific worker stack:
 
-- `docker-compose.worker-whisper.yml` consumes `transcribe.remote.pool.local.whisper.large-v3` and runs [`speaches`](https://github.com/speaches-ai/speaches)
-- `docker-compose.worker-api.yml` consumes `transcribe.remote.vendor` by default and forwards to OpenAI, DeepInfra, or a remote ASR router, depending on `TRANSCRIPTION_PROFILE`
-- `docker-compose.worker-qwen.yml` consumes `transcribe.remote.pool.local.qwen.p25` and runs [`trunk-reporter/qwen3-asr-server`](https://github.com/trunk-reporter/qwen3-asr-server)
-- `docker-compose.worker-voxtral.yml` consumes `transcribe.remote.pool.local.voxtral.realtime` and runs [`vllm serve`](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) for [`mistralai/Voxtral-Mini-4B-Realtime-2602`](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602)
+- `docker-compose.worker-whisper.yml` consumes `transcribe.model.whisper-large-v3` and runs [`speaches`](https://github.com/speaches-ai/speaches)
+- `docker-compose.worker-api.yml` consumes `transcribe.model.whisper-1` by default and forwards to OpenAI, DeepInfra, or a remote ASR router, depending on `TRANSCRIPTION_PROFILE`
+- `docker-compose.worker-qwen.yml` consumes `transcribe.model.qwen-p25` and runs [`trunk-reporter/qwen3-asr-server`](https://github.com/trunk-reporter/qwen3-asr-server)
+- `docker-compose.worker-voxtral.yml` consumes `transcribe.model.voxtral-realtime` and runs [`vllm serve`](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) for [`mistralai/Voxtral-Mini-4B-Realtime-2602`](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602)
 
 The shared `docker-compose.worker.yml` service is the `post_transcribe` worker. Keep at least one of those running somewhere in the deployment.
 
@@ -89,7 +89,7 @@ COMPOSE_FILE=docker-compose.worker-api.yml
 docker compose up -d
 ```
 
-The remote worker does not need any GPU reservation. Set `TRANSCRIPTION_PROFILE` to a vendor profile such as `kind=vendor;provider=openai;model=whisper-1` or `kind=vendor;provider=deepinfra;model=openai/whisper-large-v3-turbo`, then provide the matching API key.
+The remote worker does not need any GPU reservation. Set `TRANSCRIPTION_PROFILE` to a vendor profile such as `kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1` or `kind=vendor;model_key=whisper-large-v3-turbo;provider=deepinfra;model=openai/whisper-large-v3-turbo`, then provide the matching API key.
 
 All stacks now share one runtime boundary: the worker talks to an OpenAI-compatible `/v1/audio/transcriptions` endpoint. The difference between vendor profiles, local pools, and Vast pools is queue routing and deployment shape, not a different in-process provider implementation.
 
@@ -120,7 +120,7 @@ To use the paid Whisper API by OpenAI, run the API backend instead of the Whispe
 COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.worker-api.yml
 
 # Route new jobs to the vendor queue
-DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;provider=openai;model=whisper-1
+DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1
 OPENAI_API_KEY=my-api-key
 ```
 
@@ -132,7 +132,7 @@ To use DeepInfra's OpenAI-compatible Whisper API, run the API backend and set th
 
 ```
 # Route jobs to the vendor queue
-DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;provider=deepinfra;model=openai/whisper-large-v3-turbo
+DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;model_key=whisper-large-v3-turbo;provider=deepinfra;model=openai/whisper-large-v3-turbo
 
 # DeepInfra API key
 DEEPINFRA_API_KEY=my-api-key
@@ -178,9 +178,9 @@ COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.
 # your API key from vast.ai, or omit to have it read from ~/.vast_api_key
 VAST_API_KEY=
 # One autoscaler should manage one ASR pool queue
-AUTOSCALE_TRANSCRIPTION_PROFILE=kind=pool;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+AUTOSCALE_TRANSCRIPTION_PROFILE=kind=pool;model_key=whisper-large-v3;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
 AUTOSCALE_ASR_POOL=vast.whisper.large-v3
-AUTOSCALE_QUEUE_NAME=transcribe.remote.pool.vast.whisper.large-v3
+AUTOSCALE_QUEUE_NAME=transcribe.model.whisper-large-v3
 AUTOSCALE_INSTANCE_IMAGE=ghcr.io/crimeisdown/trunk-transcribe:main-whisper-large-v3-cuda_12.1.0
 ASR_ROUTER_ENDPOINT_TARGETS=pool.vast.whisper.large-v3
 # Tune these settings as needed

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,11 +6,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, PostgresDsn, computed_field
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
-from app.core.transcription_profiles import (
-    POST_TRANSCRIBE_QUEUE,
-    REMOTE_VENDOR_QUEUE,
-    resolve_transcription_profile,
-)
+from app.core.transcription_profiles import resolve_transcription_profile
 
 
 def parse_csv_list(value: Any) -> list[str]:
@@ -61,7 +57,7 @@ class Settings(BaseSettings):
     CELERY_QUEUES: Annotated[list[str], NoDecode, BeforeValidator(parse_csv_list)] = []
     CELERY_PREFETCH_MULTIPLIER: int = 1
     DEFAULT_TRANSCRIPTION_PROFILE: str = (
-        "kind=pool;platform=local;family=whisper;variant=large-v3;"
+        "kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;"
         "provider=speaches;model=Systran/faster-whisper-large-v3"
     )
     TRANSCRIPTION_PROFILE: str | None = None
@@ -69,6 +65,7 @@ class Settings(BaseSettings):
     ASR_API_URL: str | None = None
     ASR_ROUTER_URL: str | None = None
     ASR_MODEL: str | None = None
+    ASR_MODEL_KEY: str | None = None
     ASR_PROVIDER: str | None = None
     ASR_VARIANT: str | None = None
     ASR_POOL: str | None = None
@@ -115,10 +112,6 @@ class Settings(BaseSettings):
             explicit_profile=self.TRANSCRIPTION_PROFILE,
             default_profile=self.DEFAULT_TRANSCRIPTION_PROFILE,
         )
-
-    @property
-    def remote_vendor_queue(self) -> str:
-        return REMOTE_VENDOR_QUEUE
 
     @property
     def has_meilisearch(self) -> bool:

--- a/backend/app/core/transcription_profiles.py
+++ b/backend/app/core/transcription_profiles.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 PROFILE_KINDS = ("vendor", "pool")
-REMOTE_VENDOR_QUEUE = "transcribe.remote.vendor"
 POST_TRANSCRIBE_QUEUE = "post_transcribe"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai"
@@ -42,6 +41,7 @@ def parse_profile_string(value: str) -> dict[str, str]:
 @dataclass(frozen=True)
 class TranscriptionProfile:
     kind: Literal["vendor", "pool"]
+    model_key: str
     provider: str
     model: str
     platform: str | None = None
@@ -60,13 +60,18 @@ class TranscriptionProfile:
 
         provider = data.get("provider")
         model = data.get("model")
+        model_key = data.get("model_key")
         if not provider or not model:
             raise ValueError(
                 "Transcription profile must include provider and model fields."
             )
+        if not model_key:
+            raise ValueError("Transcription profile must include a model_key field.")
 
         if kind == "vendor":
-            return cls(kind="vendor", provider=provider, model=model)
+            return cls(
+                kind="vendor", model_key=model_key, provider=provider, model=model
+            )
 
         platform = data.get("platform")
         family = data.get("family")
@@ -77,6 +82,7 @@ class TranscriptionProfile:
             )
         return cls(
             kind="pool",
+            model_key=model_key,
             provider=provider,
             model=model,
             platform=platform,
@@ -88,6 +94,7 @@ class TranscriptionProfile:
     def canonical(self) -> str:
         parts = [
             f"kind={self.kind}",
+            f"model_key={self.model_key}",
             f"provider={self.provider}",
             f"model={self.model}",
         ]
@@ -128,22 +135,17 @@ class TranscriptionProfile:
 
     @property
     def queue_name(self) -> str:
-        if self.kind == "vendor":
-            return REMOTE_VENDOR_QUEUE
         return ".".join(
             [
                 "transcribe",
-                "remote",
-                "pool",
-                slug_token(self.platform or ""),
-                slug_token(self.family or ""),
-                slug_token(self.variant or ""),
+                "model",
+                slug_token(self.model_key),
             ]
         )
 
 
-def build_vendor_profile(provider: str, model: str) -> str:
-    return f"kind=vendor;provider={provider};model={model}"
+def build_vendor_profile(provider: str, model: str, model_key: str) -> str:
+    return f"kind=vendor;model_key={model_key};provider={provider};model={model}"
 
 
 def build_pool_profile(
@@ -153,9 +155,10 @@ def build_pool_profile(
     variant: str,
     provider: str,
     model: str,
+    model_key: str,
 ) -> str:
     return (
-        f"kind=pool;platform={platform};family={family};variant={variant};"
+        f"kind=pool;model_key={model_key};platform={platform};family={family};variant={variant};"
         f"provider={provider};model={model}"
     )
 
@@ -175,10 +178,12 @@ def infer_profile_from_legacy_env(
     whisper_implementation = os.getenv("WHISPER_IMPLEMENTATION")
 
     if whisper_implementation == "openai":
-        return build_vendor_profile("openai", "whisper-1")
+        return build_vendor_profile("openai", "whisper-1", "whisper-1")
     if whisper_implementation == "deepinfra":
         return build_vendor_profile(
-            "deepinfra", model or "openai/whisper-large-v3-turbo"
+            "deepinfra",
+            model or "openai/whisper-large-v3-turbo",
+            os.getenv("ASR_MODEL_KEY") or "whisper-large-v3-turbo",
         )
 
     family = backend or "whisper"
@@ -205,6 +210,7 @@ def infer_profile_from_legacy_env(
         variant=variant,
         provider=provider,
         model=model,
+        model_key=os.getenv("ASR_MODEL_KEY") or f"{family}-{variant}",
     )
 
 

--- a/backend/app/whisper/task.py
+++ b/backend/app/whisper/task.py
@@ -19,10 +19,13 @@ class TranscriptionTask(Task):
     model_lock = Lock()
 
     def model(self, transcription_profile: str | None = None) -> BaseWhisper:
-        profile = self.resolve_profile(transcription_profile)
-        if profile.canonical not in self._models:
-            self._models[profile.canonical] = self.initialize_model(profile.canonical)
-        return self._models[profile.canonical]
+        self.validate_requested_profile(transcription_profile)
+        worker_profile = self.worker_profile
+        if worker_profile.canonical not in self._models:
+            self._models[worker_profile.canonical] = self.initialize_model(
+                worker_profile.canonical
+            )
+        return self._models[worker_profile.canonical]
 
     def resolve_profile(
         self, transcription_profile: str | None = None
@@ -37,15 +40,33 @@ class TranscriptionTask(Task):
     def resolve_provider_and_model(
         self, transcription_profile: str | None = None
     ) -> tuple[str, str]:
-        profile = self.resolve_profile(transcription_profile)
+        self.validate_requested_profile(transcription_profile)
+        profile = self.worker_profile
         return profile.provider, profile.model
 
     @property
     def default_profile(self) -> str:
+        return self.worker_profile.canonical
+
+    @property
+    def worker_profile(self) -> TranscriptionProfile:
         return resolve_transcription_profile(
             explicit_profile=os.getenv("TRANSCRIPTION_PROFILE"),
             default_profile=os.getenv("DEFAULT_TRANSCRIPTION_PROFILE"),
-        ).canonical
+        )
+
+    def validate_requested_profile(self, transcription_profile: str | None = None) -> None:
+        if transcription_profile is None:
+            return
+
+        requested_profile = self.resolve_profile(transcription_profile)
+        worker_profile = self.worker_profile
+        if requested_profile.model_key != worker_profile.model_key:
+            raise RuntimeError(
+                "Worker model_key mismatch: "
+                f"task requested {requested_profile.model_key!r}, "
+                f"worker is configured for {worker_profile.model_key!r}."
+            )
 
     def initialize_model(self, transcription_profile: str) -> BaseWhisper:
         with self.model_lock:

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -15,11 +15,11 @@ from celery import Celery, signals, states
 from celery.exceptions import Reject
 from sentry_sdk.integrations.celery import CeleryIntegration
 
-from app.core.config import (
+from app.core.config import settings
+from app.core.transcription_profiles import (
     POST_TRANSCRIBE_QUEUE,
-    settings,
+    resolve_transcription_profile,
 )
-from app.core.transcription_profiles import resolve_transcription_profile
 from app.utils import api_client
 from app.utils.exceptions import before_send
 from app.utils.storage import fetch_audio

--- a/backend/tests/api/test_routes.py
+++ b/backend/tests/api/test_routes.py
@@ -45,6 +45,7 @@ class TestApiRoutes(unittest.TestCase):
             variant="large-v3",
             provider="speaches",
             model="Systran/faster-whisper-large-v3",
+            model_key="whisper-large-v3",
         )
 
         with patch.dict("os.environ", {"API_KEY": ""}, clear=False):
@@ -79,7 +80,7 @@ class TestApiRoutes(unittest.TestCase):
         metadata = build_metadata(audio_type="analog")
         db_call = SimpleNamespace(id=42)
         queue_result = SimpleNamespace(id="task-456")
-        profile = build_vendor_profile("openai", "whisper-1")
+        profile = build_vendor_profile("openai", "whisper-1", "whisper-1")
 
         app.dependency_overrides[get_db] = lambda: object()
         try:

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -2,7 +2,6 @@ import unittest
 
 from app.core.config import parse_csv_list
 from app.core.transcription_profiles import (
-    REMOTE_VENDOR_QUEUE,
     build_pool_profile,
     build_vendor_profile,
     resolve_transcription_profile,
@@ -40,13 +39,14 @@ class TestParseCsvList(unittest.TestCase):
 class TestTranscriptionProfiles(unittest.TestCase):
     def test_vendor_profile_routes_to_vendor_queue(self):
         profile = resolve_transcription_profile(
-            build_vendor_profile("openai", "whisper-1")
+            build_vendor_profile("openai", "whisper-1", "whisper-large-v3")
         )
         self.assertEqual("vendor", profile.kind)
+        self.assertEqual("whisper-large-v3", profile.model_key)
         self.assertEqual("openai", profile.provider)
         self.assertEqual("whisper-1", profile.model)
         self.assertEqual("vendor.openai", profile.endpoint_target)
-        self.assertEqual(REMOTE_VENDOR_QUEUE, profile.queue_name)
+        self.assertEqual("transcribe.model.whisper-large-v3", profile.queue_name)
         self.assertIsNone(profile.asr_pool)
 
     def test_pool_profile_routes_to_pool_queue(self):
@@ -57,14 +57,37 @@ class TestTranscriptionProfiles(unittest.TestCase):
                 variant="large-v3",
                 provider="speaches",
                 model="Systran/faster-whisper-large-v3",
+                model_key="whisper-large-v3",
             )
         )
         self.assertEqual("pool", profile.kind)
+        self.assertEqual("whisper-large-v3", profile.model_key)
         self.assertEqual("pool.vast.whisper.large-v3", profile.endpoint_target)
         self.assertEqual("vast.whisper.large-v3", profile.asr_pool)
-        self.assertEqual(
-            "transcribe.remote.pool.vast.whisper.large-v3", profile.queue_name
+        self.assertEqual("transcribe.model.whisper-large-v3", profile.queue_name)
+
+    def test_vendor_and_pool_profiles_share_model_key_queue(self):
+        vendor = resolve_transcription_profile(
+            build_vendor_profile("deepinfra", "openai/whisper-large-v3", "whisper-large-v3")
         )
+        pool = resolve_transcription_profile(
+            build_pool_profile(
+                platform="local",
+                family="whisper",
+                variant="large-v3",
+                provider="speaches",
+                model="Systran/faster-whisper-large-v3",
+                model_key="whisper-large-v3",
+            )
+        )
+        self.assertEqual(vendor.queue_name, pool.queue_name)
+
+    def test_profile_requires_model_key(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Transcription profile must include a model_key field",
+        ):
+            resolve_transcription_profile("kind=vendor;provider=openai;model=whisper-1")
 
     def test_pool_profile_requires_platform_family_variant(self):
         with self.assertRaisesRegex(
@@ -72,7 +95,7 @@ class TestTranscriptionProfiles(unittest.TestCase):
             "Pool transcription profiles must include platform, family, and variant fields",
         ):
             resolve_transcription_profile(
-                "kind=pool;provider=speaches;model=Systran/faster-whisper-large-v3"
+                "kind=pool;model_key=whisper-large-v3;provider=speaches;model=Systran/faster-whisper-large-v3"
             )
 
     def test_slug_token_normalizes_separators(self):

--- a/backend/tests/test_worker_routing.py
+++ b/backend/tests/test_worker_routing.py
@@ -32,21 +32,21 @@ class TestWorkerRouting(unittest.TestCase):
     def test_get_transcription_queue_defaults_to_local_whisper_pool(self):
         with patch.dict("os.environ", {}, clear=True):
             self.assertEqual(
-                "transcribe.remote.pool.local.whisper.large-v3",
+                "transcribe.model.whisper-large-v3",
                 worker.get_transcription_queue(),
             )
 
     def test_get_transcription_queue_routes_vendor_profiles(self):
         self.assertEqual(
-            "transcribe.remote.vendor",
+            "transcribe.model.whisper-1",
             worker.get_transcription_queue(
-                build_vendor_profile("openai", "whisper-1")
+                build_vendor_profile("openai", "whisper-1", "whisper-1")
             ),
         )
 
     def test_get_transcription_queue_routes_pool_profiles(self):
         self.assertEqual(
-            "transcribe.remote.pool.vast.whisper.large-v3",
+            "transcribe.model.whisper-large-v3",
             worker.get_transcription_queue(
                 build_pool_profile(
                     platform="vast",
@@ -54,6 +54,7 @@ class TestWorkerRouting(unittest.TestCase):
                     variant="large-v3",
                     provider="speaches",
                     model="Systran/faster-whisper-large-v3",
+                    model_key="whisper-large-v3",
                 )
             ),
         )
@@ -80,6 +81,7 @@ class TestWorkerRouting(unittest.TestCase):
             variant="large-v3",
             provider="speaches",
             model="Systran/faster-whisper-large-v3",
+            model_key="whisper-large-v3",
         )
 
         with patch("app.worker.transcribe_task.s", return_value=transcribe_signature):
@@ -95,7 +97,7 @@ class TestWorkerRouting(unittest.TestCase):
 
         self.assertEqual("queued", result)
         transcribe_signature.set.assert_called_once_with(
-            queue="transcribe.remote.pool.vast.whisper.large-v3"
+            queue="transcribe.model.whisper-large-v3"
         )
         post_signature.set.assert_called_once_with(queue="post_transcribe")
         chain_result.apply_async.assert_called_once_with()
@@ -126,13 +128,15 @@ class TestWorkerRouting(unittest.TestCase):
                     {"audio_type": "analog"},
                     options,
                     transcription_profile=build_vendor_profile(
-                        "deepinfra", "openai/whisper-large-v3-turbo"
+                        "deepinfra",
+                        "openai/whisper-large-v3-turbo",
+                        "whisper-large-v3-turbo",
                     ),
                 )
 
         self.assertEqual("queued", result)
         transcribe_signature.set.assert_called_once_with(
-            queue="transcribe.remote.vendor"
+            queue="transcribe.model.whisper-large-v3-turbo"
         )
         post_signature.set.assert_called_once_with(queue="post_transcribe")
         chain_result.apply_async.assert_called_once_with()

--- a/backend/tests/whisper/test_implementations.py
+++ b/backend/tests/whisper/test_implementations.py
@@ -163,7 +163,7 @@ class TestWhisperImplementations(unittest.TestCase):
 
         with patch.dict(os.environ, {"OPENAI_API_KEY": "openai-key"}, clear=True):
             implementation = TranscriptionTask().initialize_model(
-                build_vendor_profile("openai", "whisper-1")
+                build_vendor_profile("openai", "whisper-1", "whisper-1")
             )
 
         self.assertIsInstance(implementation, WhisperAsrApi)
@@ -184,7 +184,7 @@ class TestWhisperImplementations(unittest.TestCase):
             clear=True,
         ):
             implementation = TranscriptionTask().initialize_model(
-                build_vendor_profile("deepinfra", "model-x")
+                build_vendor_profile("deepinfra", "model-x", "model-x")
             )
 
         self.assertIsInstance(implementation, WhisperAsrApi)
@@ -210,6 +210,7 @@ class TestWhisperImplementations(unittest.TestCase):
                     variant="large-v3",
                     provider="speaches",
                     model="Systran/faster-whisper-large-v3",
+                    model_key="whisper-large-v3",
                 )
             )
 

--- a/backend/tests/whisper/test_task_model_selection.py
+++ b/backend/tests/whisper/test_task_model_selection.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
 from app.core.transcription_profiles import build_pool_profile, build_vendor_profile
 from app.whisper.task import TranscriptionTask
@@ -14,13 +14,16 @@ class TestTranscriptionTaskModelSelection(unittest.TestCase):
     def test_default_profile_uses_local_whisper_defaults(self):
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(
-                "kind=pool;provider=speaches;model=Systran/faster-whisper-large-v3;platform=local;family=whisper;variant=large-v3",
+                "kind=pool;model_key=whisper-large-v3;provider=speaches;model=Systran/faster-whisper-large-v3;platform=local;family=whisper;variant=large-v3",
                 self.task.default_profile,
             )
 
     def test_resolve_profile_uses_explicit_vendor_profile(self):
-        profile = self.task.resolve_profile(build_vendor_profile("openai", "whisper-1"))
+        profile = self.task.resolve_profile(
+            build_vendor_profile("openai", "whisper-1", "whisper-large-v3")
+        )
         self.assertEqual("vendor", profile.kind)
+        self.assertEqual("whisper-large-v3", profile.model_key)
         self.assertEqual("openai", profile.provider)
         self.assertEqual("whisper-1", profile.model)
 
@@ -32,6 +35,7 @@ class TestTranscriptionTaskModelSelection(unittest.TestCase):
                 variant="large-v3",
                 provider="speaches",
                 model="Systran/faster-whisper-large-v3",
+                model_key="whisper-large-v3",
             )
         )
         self.assertEqual("pool", profile.kind)
@@ -39,46 +43,64 @@ class TestTranscriptionTaskModelSelection(unittest.TestCase):
         self.assertEqual("large-v3", profile.variant)
 
     def test_resolve_provider_and_model_for_vendor(self):
-        self.assertEqual(
-            ("openai", "whisper-1"),
-            self.task.resolve_provider_and_model(
-                build_vendor_profile("openai", "whisper-1")
-            ),
-        )
+        profile = build_vendor_profile("openai", "whisper-1", "whisper-1")
+        with patch.dict(os.environ, {"TRANSCRIPTION_PROFILE": profile}, clear=True):
+            self.assertEqual(
+                ("openai", "whisper-1"),
+                self.task.resolve_provider_and_model(profile),
+            )
 
     def test_model_uses_default_profile_when_not_provided(self):
         expected_model = Mock()
-        with patch.object(
-            TranscriptionTask,
-            "default_profile",
-            new_callable=PropertyMock,
-            return_value=build_vendor_profile("openai", "whisper-1"),
+        profile = build_vendor_profile("openai", "whisper-1", "whisper-1")
+        with patch.dict(
+            os.environ,
+            {"TRANSCRIPTION_PROFILE": profile, "OPENAI_API_KEY": "openai-key"},
+            clear=True,
         ):
             with patch.object(
                 self.task, "initialize_model", return_value=expected_model
             ) as initialize_model_mock:
                 model = self.task.model()
         self.assertIs(expected_model, model)
-        initialize_model_mock.assert_called_once_with(
-            build_vendor_profile("openai", "whisper-1")
-        )
+        initialize_model_mock.assert_called_once_with(profile)
 
     def test_model_caches_initialized_models(self):
         expected_model = Mock()
-        profile = build_vendor_profile("openai", "whisper-1")
-        with patch.object(
-            self.task, "initialize_model", return_value=expected_model
-        ) as initialize_model_mock:
-            model_1 = self.task.model(profile)
-            model_2 = self.task.model(profile)
+        profile = build_vendor_profile("openai", "whisper-1", "whisper-1")
+        with patch.dict(
+            os.environ,
+            {"TRANSCRIPTION_PROFILE": profile, "OPENAI_API_KEY": "openai-key"},
+            clear=True,
+        ):
+            with patch.object(
+                self.task, "initialize_model", return_value=expected_model
+            ) as initialize_model_mock:
+                model_1 = self.task.model(profile)
+                model_2 = self.task.model(profile)
 
         self.assertIs(model_1, model_2)
         initialize_model_mock.assert_called_once_with(profile)
 
+    def test_model_rejects_task_with_different_model_key(self):
+        worker_profile = build_vendor_profile("openai", "whisper-1", "whisper-1")
+        task_profile = build_vendor_profile(
+            "deepinfra", "openai/whisper-large-v3", "whisper-large-v3"
+        )
+        with patch.dict(
+            os.environ,
+            {"TRANSCRIPTION_PROFILE": worker_profile},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Worker model_key mismatch"):
+                self.task.model(task_profile)
+
     def test_initialize_model_openai_requires_api_key(self):
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaisesRegex(RuntimeError, "OPENAI_API_KEY env must be set"):
-                self.task.initialize_model(build_vendor_profile("openai", "whisper-1"))
+                self.task.initialize_model(
+                    build_vendor_profile("openai", "whisper-1", "whisper-1")
+                )
 
     def test_initialize_model_deepinfra_requires_api_key(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -87,7 +109,9 @@ class TestTranscriptionTaskModelSelection(unittest.TestCase):
             ):
                 self.task.initialize_model(
                     build_vendor_profile(
-                        "deepinfra", "openai/whisper-large-v3-turbo"
+                        "deepinfra",
+                        "openai/whisper-large-v3-turbo",
+                        "whisper-large-v3-turbo",
                     )
                 )
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -20,7 +20,7 @@ services:
       - ./docker/healthcheck.sh:/usr/local/bin/healthcheck.sh
     env_file: .env
     environment:
-      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3}
+      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3}
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/api/v1/healthz"]
@@ -78,7 +78,7 @@ services:
     environment:
       - CELERY_BROKER_URL
       - CELERY_RESULT_BACKEND
-      - CELERY_QUEUES=transcribe.remote.vendor,transcribe.remote.pool.local.whisper.large-v3,transcribe.remote.pool.local.qwen.p25,transcribe.remote.pool.local.voxtral.realtime,transcribe.remote.pool.vast.whisper.large-v3,post_transcribe
+      - CELERY_QUEUES=transcribe.model.whisper-1,transcribe.model.whisper-large-v3,transcribe.model.whisper-large-v3-turbo,transcribe.model.qwen-p25,transcribe.model.voxtral-realtime,post_transcribe
       - FLOWER_PURGE_OFFLINE_WORKERS=120
       - FLOWER_PERSISTENT=1
       - FLOWER_DB=/src/data/flower

--- a/docker-compose.worker-api.yml
+++ b/docker-compose.worker-api.yml
@@ -15,9 +15,9 @@ services:
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
-      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=vendor;provider=openai;model=whisper-1}
-      - TRANSCRIPTION_PROFILE=${TRANSCRIPTION_PROFILE:-kind=vendor;provider=openai;model=whisper-1}
-      - CELERY_QUEUES=${CELERY_QUEUES:-transcribe.remote.vendor}
+      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1}
+      - TRANSCRIPTION_PROFILE=${TRANSCRIPTION_PROFILE:-kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1}
+      - CELERY_QUEUES=${CELERY_QUEUES:-transcribe.model.whisper-1}
       - WHISPER_MODEL
       - OPENAI_API_KEY
       - DEEPINFRA_API_KEY

--- a/docker-compose.worker-qwen.yml
+++ b/docker-compose.worker-qwen.yml
@@ -15,9 +15,9 @@ services:
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
-      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25}
-      - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25
-      - CELERY_QUEUES=transcribe.remote.pool.local.qwen.p25
+      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;model_key=qwen-p25;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25}
+      - TRANSCRIPTION_PROFILE=kind=pool;model_key=qwen-p25;platform=local;family=qwen;variant=p25;provider=qwen3-asr-server;model=qwen3-asr-p25
+      - CELERY_QUEUES=transcribe.model.qwen-p25
       - ASR_API_URL=${ASR_API_URL:-http://asr-qwen:8765/v1}
       - ASR_PROVIDER=${ASR_PROVIDER:-qwen3-asr-server}
       - ASR_VARIANT=${ASR_VARIANT:-p25}

--- a/docker-compose.worker-voxtral.yml
+++ b/docker-compose.worker-voxtral.yml
@@ -15,9 +15,9 @@ services:
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
-      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602}
-      - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602
-      - CELERY_QUEUES=transcribe.remote.pool.local.voxtral.realtime
+      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;model_key=voxtral-realtime;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602}
+      - TRANSCRIPTION_PROFILE=kind=pool;model_key=voxtral-realtime;platform=local;family=voxtral;variant=realtime;provider=vllm;model=mistralai/Voxtral-Mini-4B-Realtime-2602
+      - CELERY_QUEUES=transcribe.model.voxtral-realtime
       - ASR_API_URL=${ASR_API_URL:-http://asr-voxtral:8000/v1}
       - ASR_PROVIDER=${ASR_PROVIDER:-vllm}
       - ASR_VARIANT=${ASR_VARIANT:-realtime}

--- a/docker-compose.worker-whisper.yml
+++ b/docker-compose.worker-whisper.yml
@@ -15,9 +15,9 @@ services:
       - ./docker/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./docker/celery-healthcheck.sh:/usr/local/bin/celery-healthcheck.sh
     environment:
-      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3}
-      - TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
-      - CELERY_QUEUES=transcribe.remote.pool.local.whisper.large-v3
+      - DEFAULT_TRANSCRIPTION_PROFILE=${DEFAULT_TRANSCRIPTION_PROFILE:-kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3}
+      - TRANSCRIPTION_PROFILE=kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
+      - CELERY_QUEUES=transcribe.model.whisper-large-v3
       - ASR_API_URL=${ASR_API_URL:-http://asr-whisper:8000/v1}
       - ASR_PROVIDER=${ASR_PROVIDER:-speaches}
       - ASR_VARIANT=${ASR_VARIANT:-large-v3}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,11 +20,11 @@ flowchart LR
     end
 
     subgraph QUEUES[RabbitMQ queues]
-        QVENDOR[transcribe.remote.vendor]
-        QWL[transcribe.remote.pool.local.whisper.large-v3]
-        QQL[transcribe.remote.pool.local.qwen.p25]
-        QVL[transcribe.remote.pool.local.voxtral.realtime]
-        QWV[transcribe.remote.pool.vast.whisper.large-v3]
+        QW1[transcribe.model.whisper-1]
+        QWL[transcribe.model.whisper-large-v3]
+        QWT[transcribe.model.whisper-large-v3-turbo]
+        QQL[transcribe.model.qwen-p25]
+        QVL[transcribe.model.voxtral-realtime]
         QP[post_transcribe]
     end
 
@@ -57,17 +57,18 @@ flowchart LR
     end
 
     TR -->|upload call + metadata| API
-    API -->|enqueue by transcription_profile| QVENDOR
-    API -->|enqueue by transcription_profile| QWL
-    API -->|enqueue by transcription_profile| QQL
-    API -->|enqueue by transcription_profile| QVL
-    API -->|enqueue by transcription_profile| QWV
+    API -->|enqueue by transcription_profile model_key| QW1
+    API -->|enqueue by transcription_profile model_key| QWL
+    API -->|enqueue by transcription_profile model_key| QWT
+    API -->|enqueue by transcription_profile model_key| QQL
+    API -->|enqueue by transcription_profile model_key| QVL
 
-    QVENDOR --> WR -->|POST /v1/audio/transcriptions| PA
+    QW1 --> WR -->|POST /v1/audio/transcriptions| PA
     QWL --> WP -->|POST /v1/audio/transcriptions| PW
+    QWL --> WR -->|POST /v1/audio/transcriptions + X-ASR-Endpoint-Target| PR
+    QWT --> WR -->|POST /v1/audio/transcriptions| PA
     QQL --> WQ -->|POST /v1/audio/transcriptions| PQW
     QVL --> WV -->|POST /v1/audio/transcriptions| PV
-    QWV --> WR -->|POST /v1/audio/transcriptions + X-ASR-Endpoint-Target| PR
     PR -->|load balance| PW
 
     PW -->|normalized transcript| QP
@@ -90,11 +91,11 @@ flowchart LR
 
 | Profile | Queue | Worker compose | Provider server | Default model |
 | --- | --- | --- | --- | --- |
-| `kind=vendor;provider=openai;model=whisper-1` | `transcribe.remote.vendor` | `docker-compose.worker-api.yml` | OpenAI | `whisper-1` |
-| `kind=pool;platform=local;family=whisper;variant=large-v3;...` | `transcribe.remote.pool.local.whisper.large-v3` | `docker-compose.worker-whisper.yml` | `ghcr.io/speaches-ai/speaches` | `Systran/faster-whisper-large-v3` |
-| `kind=pool;platform=local;family=qwen;variant=p25;...` | `transcribe.remote.pool.local.qwen.p25` | `docker-compose.worker-qwen.yml` | `ghcr.io/trunk-reporter/qwen3-asr-server:gpu` | `qwen3-asr-p25` |
-| `kind=pool;platform=local;family=voxtral;variant=realtime;...` | `transcribe.remote.pool.local.voxtral.realtime` | `docker-compose.worker-voxtral.yml` | `vllm/vllm-openai:latest` | `mistralai/Voxtral-Mini-4B-Realtime-2602` |
-| `kind=pool;platform=vast;family=whisper;variant=large-v3;...` | `transcribe.remote.pool.vast.whisper.large-v3` | `docker-compose.worker-api.yml` + `asr-router` | Vast ASR pool | `Systran/faster-whisper-large-v3` |
+| `kind=vendor;model_key=whisper-1;provider=openai;model=whisper-1` | `transcribe.model.whisper-1` | `docker-compose.worker-api.yml` | OpenAI | `whisper-1` |
+| `kind=pool;model_key=whisper-large-v3;platform=local;family=whisper;variant=large-v3;...` | `transcribe.model.whisper-large-v3` | `docker-compose.worker-whisper.yml` | `ghcr.io/speaches-ai/speaches` | `Systran/faster-whisper-large-v3` |
+| `kind=pool;model_key=qwen-p25;platform=local;family=qwen;variant=p25;...` | `transcribe.model.qwen-p25` | `docker-compose.worker-qwen.yml` | `ghcr.io/trunk-reporter/qwen3-asr-server:gpu` | `qwen3-asr-p25` |
+| `kind=pool;model_key=voxtral-realtime;platform=local;family=voxtral;variant=realtime;...` | `transcribe.model.voxtral-realtime` | `docker-compose.worker-voxtral.yml` | `vllm/vllm-openai:latest` | `mistralai/Voxtral-Mini-4B-Realtime-2602` |
+| `kind=pool;model_key=whisper-large-v3;platform=vast;family=whisper;variant=large-v3;...` | `transcribe.model.whisper-large-v3` | `docker-compose.worker-api.yml` + `asr-router` | Vast ASR pool | `Systran/faster-whisper-large-v3` |
 
 ## Runtime Contract
 
@@ -104,12 +105,12 @@ All active transcription backends in this repo now use the same runtime contract
 - the provider returns a verbose JSON transcript
 - the worker normalizes that response into the shared transcript shape used by `post_transcribe`
 
-That means queue routing is still backend-specific, but execution is no longer split between local ASR servers and separate in-process provider SDK implementations.
+That means queue routing is model-specific, while execution strategy stays worker-specific.
 
 ## Notes
 
-- Each machine should run one profile-specific worker stack plus any shared infrastructure it needs to reach RabbitMQ and the API.
+- Each machine should run one model-specific worker stack plus any shared infrastructure it needs to reach RabbitMQ and the API.
 - The worker normalizes transcripts before handing them to the shared `post_transcribe` flow.
 - Vendor profiles are forwarding-only and do not need GPU capacity.
-- `autoscale-vast` manages one ASR pool queue per autoscaler instance.
+- `autoscale-vast` watches one model queue per autoscaler instance while using `ASR_POOL` for Vast instance discovery.
 - Flower observes queue and worker state; it is not on the transcript data path.


### PR DESCRIPTION
## Summary

- Add required `model_key` to transcription profiles and route transcription queues as `transcribe.model.<model_key>`.
- Let workers use their own configured provider/API endpoint while validating that consumed tasks match the worker `model_key`.
- Update worker compose defaults, env examples, README, architecture docs, and focused tests for the hard queue-name cutover.

## Validation

- `uv run --directory backend pytest tests/core/test_config.py tests/test_worker_routing.py tests/whisper/test_task_model_selection.py tests/whisper/test_implementations.py tests/api/test_routes.py`
- `uv run --directory backend ruff check app tests/core/test_config.py tests/test_worker_routing.py tests/whisper/test_task_model_selection.py tests/whisper/test_implementations.py tests/api/test_routes.py`