### PR TITLE
[codex] add Cloudflare Workers AI transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ DEFAULT_TRANSCRIPTION_PROFILE=kind=pool;platform=local;family=whisper;variant=la
 # Examples:
 # kind=vendor;provider=openai;model=whisper-1
 # kind=vendor;provider=deepinfra;model=openai/whisper-large-v3-turbo
+# kind=vendor;provider=cloudflare;model=@cf/openai/whisper-large-v3-turbo
 # kind=pool;platform=vast;family=whisper;variant=large-v3;provider=speaches;model=Systran/faster-whisper-large-v3
 
 # Legacy compatibility only. Prefer TRANSCRIPTION_PROFILE instead.
@@ -59,6 +60,12 @@ CUDA_VERSION=12.1.0
 # DEEPINFRA_API_KEY=
 # Optional override for DeepInfra base URL
 # DEEPINFRA_BASE_URL=https://api.deepinfra.com/v1/openai
+
+# Cloudflare Workers AI, if using a vendor Cloudflare transcription profile
+# CLOUDFLARE_ACCOUNT_ID=
+# CLOUDFLARE_API_TOKEN=
+# Optional override for Cloudflare Workers AI base run URL
+# CLOUDFLARE_BASE_URL=https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run
 
 #
 # Queue settings

--- a/README.md
+++ b/README.md
@@ -138,7 +138,20 @@ DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;provider=deepinfra;model=openai/whispe
 DEEPINFRA_API_KEY=my-api-key
 ```
 
-In both cases, the worker still uses the same `POST /v1/audio/transcriptions` contract that it uses for the local Whisper, Qwen, and Voxtral servers.
+### Running workers using Cloudflare Workers AI
+
+To use Cloudflare Workers AI with `@cf/openai/whisper-large-v3-turbo`, run the API backend and set the following in your `.env` file:
+
+```
+# Route jobs to the vendor queue
+DEFAULT_TRANSCRIPTION_PROFILE=kind=vendor;provider=cloudflare;model=@cf/openai/whisper-large-v3-turbo
+
+# Cloudflare Workers AI credentials
+CLOUDFLARE_ACCOUNT_ID=my-account-id
+CLOUDFLARE_API_TOKEN=my-api-token
+```
+
+OpenAI and DeepInfra use the same `POST /v1/audio/transcriptions` contract as the local Whisper, Qwen, and Voxtral servers. Cloudflare uses the Workers AI REST endpoint and the worker normalizes its response into the same transcript shape.
 
 ### Running workers on Windows
 

--- a/backend/app/core/transcription_profiles.py
+++ b/backend/app/core/transcription_profiles.py
@@ -10,6 +10,7 @@ REMOTE_VENDOR_QUEUE = "transcribe.remote.vendor"
 POST_TRANSCRIBE_QUEUE = "post_transcribe"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai"
+DEFAULT_CLOUDFLARE_MODEL = "@cf/openai/whisper-large-v3-turbo"
 
 
 def slug_token(value: str) -> str:
@@ -180,6 +181,8 @@ def infer_profile_from_legacy_env(
         return build_vendor_profile(
             "deepinfra", model or "openai/whisper-large-v3-turbo"
         )
+    if whisper_implementation == "cloudflare":
+        return build_vendor_profile("cloudflare", model or DEFAULT_CLOUDFLARE_MODEL)
 
     family = backend or "whisper"
     platform = "local"

--- a/backend/app/whisper/cloudflare_ai.py
+++ b/backend/app/whisper/cloudflare_ai.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+
+import requests
+
+from .base import BaseWhisper, TranscribeOptions, WhisperResult
+
+
+class CloudflareAiWhisper(BaseWhisper):
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        headers: dict[str, str] | None = None,
+    ):
+        self.client = requests.Session()
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.headers = headers or {}
+
+    def _normalize_response(self, response_data: dict, language: str) -> WhisperResult:
+        result = response_data.get("result", response_data)
+        segments = result.get("segments") or []
+        if not segments and result.get("text"):
+            segments = [
+                {"start": float(i), "end": float(i + 1), "text": line}
+                for i, line in enumerate(
+                    [line.strip() for line in result["text"].splitlines() if line.strip()]
+                )
+            ]
+        return {
+            "text": result.get("text", ""),
+            "segments": segments,
+            "language": result.get("language", language),
+        }
+
+    def transcribe(
+        self,
+        audio: str,
+        options: TranscribeOptions,
+        language: str = "en",
+    ) -> WhisperResult:
+        with open(audio, "rb") as audio_file:
+            audio_base64 = base64.b64encode(audio_file.read()).decode("utf-8")
+
+        payload = {
+            "audio": audio_base64,
+            "language": language,
+            "task": "transcribe",
+            "initial_prompt": options["initial_prompt"] or "",
+        }
+        payload.update(options.get("decode_options") or {})
+        if options.get("vad_filter"):
+            payload["vad_filter"] = True
+
+        response = self.client.post(
+            f"{self.base_url}/{self.model}",
+            json=payload,
+            headers=self.headers,
+            timeout=120,
+        )
+        response.raise_for_status()
+        return self._normalize_response(response.json(), language)

--- a/backend/app/whisper/task.py
+++ b/backend/app/whisper/task.py
@@ -50,6 +50,15 @@ class TranscriptionTask(Task):
     def initialize_model(self, transcription_profile: str) -> BaseWhisper:
         with self.model_lock:
             profile = self.resolve_profile(transcription_profile)
+            if profile.kind == "vendor" and profile.provider == "cloudflare":
+                from .cloudflare_ai import CloudflareAiWhisper
+
+                return CloudflareAiWhisper(
+                    base_url=self._get_profile_base_url(profile),
+                    model=profile.model,
+                    headers=self._get_profile_headers(profile),
+                )
+
             from .whisper_asr_api import WhisperAsrApi
 
             headers = self._get_profile_headers(profile)
@@ -75,6 +84,16 @@ class TranscriptionTask(Task):
                 return os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL)
             if profile.provider == "deepinfra":
                 return os.getenv("DEEPINFRA_BASE_URL", DEFAULT_DEEPINFRA_BASE_URL)
+            if profile.provider == "cloudflare":
+                if base_url := os.getenv("CLOUDFLARE_BASE_URL"):
+                    return base_url
+                account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
+                if not account_id:
+                    raise RuntimeError("CLOUDFLARE_ACCOUNT_ID env must be set.")
+                return (
+                    "https://api.cloudflare.com/client/v4/accounts/"
+                    f"{account_id}/ai/run"
+                )
             raise RuntimeError(f"Unsupported vendor provider {profile.provider}")
 
         if profile.platform == "vast":
@@ -99,6 +118,12 @@ class TranscriptionTask(Task):
                 api_key = os.getenv("DEEPINFRA_API_KEY")
                 if not api_key:
                     raise RuntimeError("DEEPINFRA_API_KEY env must be set.")
+                headers["Authorization"] = f"Bearer {api_key}"
+                return headers
+            if profile.provider == "cloudflare":
+                api_key = os.getenv("CLOUDFLARE_API_TOKEN")
+                if not api_key:
+                    raise RuntimeError("CLOUDFLARE_API_TOKEN env must be set.")
                 headers["Authorization"] = f"Bearer {api_key}"
                 return headers
             raise RuntimeError(f"Unsupported vendor provider {profile.provider}")

--- a/backend/scripts/transcribe.py
+++ b/backend/scripts/transcribe.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from app.whisper.base import TranscribeOptions
 from app.whisper.transcribe import cleanup_transcript
 from app.core.transcription_profiles import (
+    DEFAULT_CLOUDFLARE_MODEL,
     build_pool_profile,
     build_vendor_profile,
 )
@@ -49,8 +50,13 @@ def main():
 
     profile = args.profile
     if not profile:
-        if args.provider in {"openai", "deepinfra"}:
-            profile = build_vendor_profile(args.provider, args.model)
+        if args.provider in {"openai", "deepinfra", "cloudflare"}:
+            model = args.model
+            if args.provider == "cloudflare" and args.model == os.getenv(
+                "WHISPER_MODEL", "Systran/faster-distil-whisper-small.en"
+            ):
+                model = DEFAULT_CLOUDFLARE_MODEL
+            profile = build_vendor_profile(args.provider, model)
         else:
             profile = build_pool_profile(
                 platform="local",

--- a/backend/tests/whisper/test_implementations.py
+++ b/backend/tests/whisper/test_implementations.py
@@ -194,6 +194,85 @@ class TestWhisperImplementations(unittest.TestCase):
             {"Authorization": "Bearer deepinfra-key"}, implementation.headers
         )
 
+    def test_cloudflare_ai_transcribe_structural_contract(self):
+        from app.whisper.cloudflare_ai import CloudflareAiWhisper
+
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "success": True,
+            "result": {
+                "text": "cloudflare asr",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "cloudflare asr"}],
+            },
+        }
+        session = Mock()
+        session.post.return_value = response
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
+            create_tiny_wav(temp_audio.name)
+            audio_path = temp_audio.name
+
+        try:
+            with patch(
+                "app.whisper.cloudflare_ai.requests.Session", return_value=session
+            ):
+                implementation = CloudflareAiWhisper(
+                    base_url="https://api.cloudflare.com/client/v4/accounts/acct/ai/run",
+                    model="@cf/openai/whisper-large-v3-turbo",
+                    headers={"Authorization": "Bearer token"},
+                )
+                result = implementation.transcribe(
+                    audio=audio_path,
+                    options=build_options(vad_filter=True),
+                    language="en",
+                )
+
+            self.assertEqual(
+                "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/openai/whisper-large-v3-turbo",
+                session.post.call_args.args[0],
+            )
+            kwargs = session.post.call_args.kwargs
+            self.assertEqual("en", kwargs["json"]["language"])
+            self.assertEqual("transcribe", kwargs["json"]["task"])
+            self.assertEqual("alpha bravo", kwargs["json"]["initial_prompt"])
+            self.assertTrue(kwargs["json"]["vad_filter"])
+            self.assertEqual(5, kwargs["json"]["beam_size"])
+            self.assertEqual({"Authorization": "Bearer token"}, kwargs["headers"])
+            response.raise_for_status.assert_called_once()
+            self.assertEqual("en", result["language"])
+            self._assert_result_contract(result)
+        finally:
+            os.unlink(audio_path)
+
+    def test_whisper_task_initialize_model_uses_cloudflare_adapter(self):
+        from app.whisper.cloudflare_ai import CloudflareAiWhisper
+        from app.whisper.task import TranscriptionTask
+
+        with patch.dict(
+            os.environ,
+            {
+                "CLOUDFLARE_ACCOUNT_ID": "account-id",
+                "CLOUDFLARE_API_TOKEN": "cloudflare-token",
+            },
+            clear=True,
+        ):
+            implementation = TranscriptionTask().initialize_model(
+                build_vendor_profile(
+                    "cloudflare", "@cf/openai/whisper-large-v3-turbo"
+                )
+            )
+
+        self.assertIsInstance(implementation, CloudflareAiWhisper)
+        self.assertEqual(
+            "https://api.cloudflare.com/client/v4/accounts/account-id/ai/run",
+            implementation.base_url,
+        )
+        self.assertEqual("@cf/openai/whisper-large-v3-turbo", implementation.model)
+        self.assertEqual(
+            {"Authorization": "Bearer cloudflare-token"}, implementation.headers
+        )
+
     def test_transcription_task_initialize_model_uses_router_for_vast_pool(self):
         from app.whisper.task import TranscriptionTask
         from app.whisper.whisper_asr_api import WhisperAsrApi

--- a/backend/tests/whisper/test_providers_live.py
+++ b/backend/tests/whisper/test_providers_live.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from app.whisper.cloudflare_ai import CloudflareAiWhisper
 from app.whisper.whisper_asr_api import WhisperAsrApi
 
 
@@ -54,6 +55,26 @@ class TestLiveProviders(unittest.TestCase):
             model=model,
             provider="deepinfra",
             headers={"Authorization": f"Bearer {os.environ['DEEPINFRA_API_KEY']}"},
+        )
+        result = implementation.transcribe(TINY_AUDIO_FILE, build_options(), "en")
+        self._assert_result_contract(result)
+
+    @unittest.skipUnless(
+        os.getenv("CLOUDFLARE_API_TOKEN") and os.getenv("CLOUDFLARE_ACCOUNT_ID"),
+        "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID not set",
+    )
+    def test_cloudflare_live(self):
+        model = os.getenv("CLOUDFLARE_MODEL", "@cf/openai/whisper-large-v3-turbo")
+        implementation = CloudflareAiWhisper(
+            base_url=os.getenv(
+                "CLOUDFLARE_BASE_URL",
+                "https://api.cloudflare.com/client/v4/accounts/"
+                f"{os.environ['CLOUDFLARE_ACCOUNT_ID']}/ai/run",
+            ),
+            model=model,
+            headers={
+                "Authorization": f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}"
+            },
         )
         result = implementation.transcribe(TINY_AUDIO_FILE, build_options(), "en")
         self._assert_result_contract(result)

--- a/backend/tests/whisper/test_task_model_selection.py
+++ b/backend/tests/whisper/test_task_model_selection.py
@@ -91,6 +91,36 @@ class TestTranscriptionTaskModelSelection(unittest.TestCase):
                     )
                 )
 
+    def test_initialize_model_cloudflare_requires_account_id(self):
+        with patch.dict(
+            os.environ,
+            {"CLOUDFLARE_API_TOKEN": "cloudflare-token"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "CLOUDFLARE_ACCOUNT_ID env must be set"
+            ):
+                self.task.initialize_model(
+                    build_vendor_profile(
+                        "cloudflare", "@cf/openai/whisper-large-v3-turbo"
+                    )
+                )
+
+    def test_initialize_model_cloudflare_requires_api_token(self):
+        with patch.dict(
+            os.environ,
+            {"CLOUDFLARE_ACCOUNT_ID": "account-id"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "CLOUDFLARE_API_TOKEN env must be set"
+            ):
+                self.task.initialize_model(
+                    build_vendor_profile(
+                        "cloudflare", "@cf/openai/whisper-large-v3-turbo"
+                    )
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,7 @@ flowchart LR
 | Profile | Queue | Worker compose | Provider server | Default model |
 | --- | --- | --- | --- | --- |
 | `kind=vendor;provider=openai;model=whisper-1` | `transcribe.remote.vendor` | `docker-compose.worker-api.yml` | OpenAI | `whisper-1` |
+| `kind=vendor;provider=cloudflare;model=@cf/openai/whisper-large-v3-turbo` | `transcribe.remote.vendor` | `docker-compose.worker-api.yml` | Cloudflare Workers AI | `@cf/openai/whisper-large-v3-turbo` |
 | `kind=pool;platform=local;family=whisper;variant=large-v3;...` | `transcribe.remote.pool.local.whisper.large-v3` | `docker-compose.worker-whisper.yml` | `ghcr.io/speaches-ai/speaches` | `Systran/faster-whisper-large-v3` |
 | `kind=pool;platform=local;family=qwen;variant=p25;...` | `transcribe.remote.pool.local.qwen.p25` | `docker-compose.worker-qwen.yml` | `ghcr.io/trunk-reporter/qwen3-asr-server:gpu` | `qwen3-asr-p25` |
 | `kind=pool;platform=local;family=voxtral;variant=realtime;...` | `transcribe.remote.pool.local.voxtral.realtime` | `docker-compose.worker-voxtral.yml` | `vllm/vllm-openai:latest` | `mistralai/Voxtral-Mini-4B-Realtime-2602` |
@@ -98,11 +99,13 @@ flowchart LR
 
 ## Runtime Contract
 
-All active transcription backends in this repo now use the same runtime contract:
+Most active transcription backends in this repo use the same runtime contract:
 
 - the worker sends audio to an OpenAI-compatible `POST /v1/audio/transcriptions` endpoint
 - the provider returns a verbose JSON transcript
 - the worker normalizes that response into the shared transcript shape used by `post_transcribe`
+
+Cloudflare Workers AI is the vendor exception: the worker sends base64 audio to Cloudflare's `/client/v4/accounts/{account_id}/ai/run/{model}` endpoint and normalizes the returned Workers AI transcript into the same shared shape.
 
 That means queue routing is still backend-specific, but execution is no longer split between local ASR servers and separate in-process provider SDK implementations.
 


### PR DESCRIPTION
## Summary

Adds Cloudflare Workers AI as a vendor transcription provider for `@cf/openai/whisper-large-v3-turbo`.

## Changes

- Added a Cloudflare-specific ASR adapter that posts base64 audio to the Workers AI run endpoint and normalizes the response into the existing transcript shape.
- Wired `provider=cloudflare` into transcription task initialization, env-based profile inference, and the CLI helper.
- Documented the Cloudflare profile and required `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` settings.
- Added unit coverage and an opt-in live provider test alongside OpenAI and DeepInfra.

## Validation

- `PYTHONPATH=. uv run pytest tests/whisper/test_task_model_selection.py tests/whisper/test_implementations.py tests/whisper/test_providers_live.py`
- `PYTHONPATH=. uv run ruff check app/whisper/cloudflare_ai.py app/whisper/task.py app/core/transcription_profiles.py scripts/transcribe.py tests/whisper/test_task_model_selection.py tests/whisper/test_implementations.py tests/whisper/test_providers_live.py`

Result: 18 passed, 3 skipped. Live provider tests were skipped because credentials are not set locally.