### PR TITLE
Support current OpenAI transcription models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ CUDA_VERSION=12.1.0
 
 # OpenAI API key, if using the paid Whisper API (and switch your WHISPER_IMPLEMENTATION to openai)
 # OPENAI_API_KEY=
+# OpenAI transcription model. Supported examples: whisper-1, gpt-4o-transcribe,
+# gpt-4o-mini-transcribe, and gpt-4o-transcribe-diarize.
+# OPENAI_TRANSCRIPTION_MODEL=gpt-4o-transcribe
 
 # Deepgram API key, if using the Deepgram transcription API (and switch your WHISPER_IMPLEMENTATION to deepgram)
 # DEEPGRAM_API_KEY=

--- a/README.md
+++ b/README.md
@@ -65,13 +65,24 @@ To use the paid Whisper API by OpenAI instead of running the worker on a machine
 
 ```
 # To use the paid OpenAI Whisper API instead of running the model locally
-COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.openai.yml
+COMPOSE_FILE=docker-compose.server.yml:docker-compose.worker.yml:docker-compose.minio.yml
+WHISPER_IMPLEMENTATION=openai
 
 # OpenAI API key, if using the paid Whisper API
 OPENAI_API_KEY=my-api-key
+
+# Optional: defaults to whisper-1 for backward compatibility
+OPENAI_TRANSCRIPTION_MODEL=gpt-4o-transcribe
 ```
 
 You may also want to set `CELERY_CONCURRENCY` to a higher number since the GPU is not a limitation on concurrency anymore.
+
+Supported OpenAI transcription models include `whisper-1`, `gpt-4o-transcribe`,
+`gpt-4o-mini-transcribe`, and `gpt-4o-transcribe-diarize`.
+`gpt-4o-transcribe` and `gpt-4o-mini-transcribe` do not return timestamped
+segments, so trunk-transcribe stores their complete response as one untimed
+segment. The diarization model returns timestamped speaker segments, which are
+preserved.
 
 ### Running workers using DeepInfra's Whisper API
 

--- a/app/radio/analog.py
+++ b/app/radio/analog.py
@@ -3,7 +3,7 @@ import os
 from app.models.metadata import Metadata
 from app.models.transcript import Transcript
 from app.utils.cache import get_ttl_hash
-from app.whisper.base import TranscribeOptions, WhisperResult
+from app.whisper.base import TranscribeOptions, WhisperResult, format_segment_text
 from app.whisper.config import get_transcript_cleanup_config, get_whisper_config
 
 
@@ -23,7 +23,7 @@ def process_response(response: WhisperResult, metadata: Metadata) -> Transcript:
     transcript = Transcript()
 
     for segment in response["segments"]:
-        text = segment["text"].strip()
+        text = format_segment_text(segment)
         if len(text):
             # TODO: use segment["start"] and segment["end"] as well
             transcript.append(text)

--- a/app/radio/digital.py
+++ b/app/radio/digital.py
@@ -7,6 +7,7 @@ from app.whisper.base import (
     TranscribeOptions,
     WhisperSegment,
     WhisperResult,
+    format_segment_text,
 )
 from app.whisper.config import get_transcript_cleanup_config, get_whisper_config
 
@@ -45,7 +46,7 @@ def process_response(response: WhisperResult, metadata: Metadata) -> Transcript:
 
     for segment in response["segments"]:
         transcript.append(
-            segment["text"].strip(),
+            format_segment_text(segment),
             get_closest_src(metadata["srcList"], segment),
         )
 

--- a/app/whisper/base.py
+++ b/app/whisper/base.py
@@ -17,6 +17,12 @@ class WhisperResult(TypedDict):
     language: Optional[str]
 
 
+def format_segment_text(segment: WhisperSegment) -> str:
+    text = segment["text"].strip()
+    speaker = segment.get("speaker")
+    return f"Speaker {speaker}: {text}" if speaker and text else text
+
+
 class TranscribeOptions(TypedDict):
     initial_prompt: str
     cleanup: bool

--- a/app/whisper/base.py
+++ b/app/whisper/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, TypedDict
+from typing import Any, NotRequired, Optional, TypedDict
 
 from app.whisper.config import TranscriptCleanupConfig
 
@@ -8,6 +8,7 @@ class WhisperSegment(TypedDict):
     start: float
     end: float
     text: str
+    speaker: NotRequired[str]
 
 
 class WhisperResult(TypedDict):

--- a/app/whisper/openai.py
+++ b/app/whisper/openai.py
@@ -1,12 +1,71 @@
 import os
+from typing import Any
+
 from openai import OpenAI
 
-from .base import BaseWhisper, TranscribeOptions, WhisperResult
+from .base import BaseWhisper, TranscribeOptions, WhisperResult, WhisperSegment
 
 
 class OpenAIApi(BaseWhisper):
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, model: str = "whisper-1"):
         self.client = OpenAI(api_key=api_key)
+        self.model = model
+
+    @property
+    def is_diarization_model(self) -> bool:
+        return self.model.startswith("gpt-4o-transcribe-diarize")
+
+    @property
+    def response_format(self) -> str:
+        if self.model == "whisper-1":
+            return "verbose_json"
+        if self.is_diarization_model:
+            return "diarized_json"
+        return "json"
+
+    @staticmethod
+    def normalize_response(response: Any, language: str) -> WhisperResult:
+        if isinstance(response, str):
+            response_data: dict[str, Any] = {"text": response}
+        elif isinstance(response, dict):
+            response_data = response
+        else:
+            response_data = response.model_dump()
+
+        text = response_data.get("text") or ""
+        segments: list[WhisperSegment] = []
+        for raw_segment in response_data.get("segments") or []:
+            if not isinstance(raw_segment, dict):
+                raw_segment = raw_segment.model_dump()
+
+            segment: WhisperSegment = {
+                "start": float(raw_segment.get("start", 0.0)),
+                "end": float(raw_segment.get("end", 0.0)),
+                "text": raw_segment.get("text") or "",
+            }
+            if raw_segment.get("speaker") is not None:
+                segment["speaker"] = str(raw_segment["speaker"])
+            segments.append(segment)
+
+        # GPT transcription models return text-only JSON. The rest of the
+        # application consumes segments, so expose the complete transcript as
+        # one untimed segment without inventing timestamps.
+        if text and not segments:
+            segments.append(
+                {
+                    "start": 0.0,
+                    "end": float(response_data.get("duration") or 0.0),
+                    "text": text,
+                }
+            )
+        elif not text and segments:
+            text = "\n".join(segment["text"] for segment in segments)
+
+        return {
+            "text": text,
+            "segments": segments,
+            "language": response_data.get("language") or language,
+        }
 
     def transcribe(
         self,
@@ -14,16 +73,26 @@ class OpenAIApi(BaseWhisper):
         options: TranscribeOptions,
         language: str = "en",
     ) -> WhisperResult:
-        audio_file = open(audio, "rb")
         prompt = os.getenv(
             "OPENAI_PROMPT", "This is a police radio dispatch transcript."
         )
         if options["initial_prompt"]:
             prompt += " The following words may appear: " + options["initial_prompt"]
-        return self.client.audio.transcriptions.create(
-            model="whisper-1",
-            file=audio_file,
-            prompt=prompt,
-            response_format="verbose_json",
-            language=language,
-        ).model_dump()  # type: ignore
+
+        request: dict[str, Any] = {
+            "model": self.model,
+            "response_format": self.response_format,
+            "language": language,
+        }
+        if self.is_diarization_model:
+            request["chunking_strategy"] = "auto"
+        else:
+            request["prompt"] = prompt
+
+        with open(audio, "rb") as audio_file:
+            response = self.client.audio.transcriptions.create(
+                file=audio_file,
+                **request,
+            )
+
+        return self.normalize_response(response, language)

--- a/app/whisper/task.py
+++ b/app/whisper/task.py
@@ -30,7 +30,7 @@ class WhisperTask(Task):
         model_name = os.getenv("WHISPER_MODEL")
 
         if whisper_implementation == "openai":
-            model_name = "whisper-1"
+            model_name = os.getenv("OPENAI_TRANSCRIPTION_MODEL", "whisper-1")
 
         if whisper_implementation == "deepgram" and not model_name:
             model_name = "nova-2"
@@ -69,7 +69,7 @@ class WhisperTask(Task):
                     raise RuntimeError("OPENAI_API_KEY env must be set.")
                 from .openai import OpenAIApi
 
-                return OpenAIApi(api_key)
+                return OpenAIApi(api_key, model)
             if implementation == "deepgram":
                 api_key = os.getenv("DEEPGRAM_API_KEY")
                 if not api_key:

--- a/tests/radio/test_analog.py
+++ b/tests/radio/test_analog.py
@@ -28,6 +28,17 @@ class TestAnalog(unittest.TestCase):
 
         self.assertEqual(expected_transcript.json, result.json)
 
+    def test_process_response_includes_diarized_speakers(self):
+        self.response["segments"][0]["speaker"] = "A"
+        self.response["segments"][1]["speaker"] = "B"
+
+        result = process_response(self.response, {})
+
+        self.assertEqual(
+            [(None, "Speaker A: Hello"), (None, "Speaker B: world")],
+            result.transcript,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/radio/test_options.py
+++ b/tests/radio/test_options.py
@@ -6,6 +6,7 @@ from app.radio.analog import build_transcribe_options as build_analog_options
 from app.radio.digital import (
     build_transcribe_options as build_digital_options,
     get_closest_src,
+    process_response as process_digital_response,
 )
 
 
@@ -106,6 +107,26 @@ class TestTranscribeOptions(unittest.TestCase):
         closest = get_closest_src(src_list, segment)
 
         self.assertEqual(200, closest["src"])
+
+    def test_process_digital_response_includes_diarized_speaker(self):
+        metadata = build_metadata(audio_type="digital")
+        response = {
+            "text": "hello",
+            "segments": [
+                {
+                    "start": 0.65,
+                    "end": 0.8,
+                    "text": " hello",
+                    "speaker": "B",
+                }
+            ],
+            "language": "en",
+        }
+
+        result = process_digital_response(response, metadata)
+
+        self.assertEqual(metadata["srcList"][1], result.transcript[0][0])
+        self.assertEqual("Speaker B: hello", result.transcript[0][1])
 
 
 if __name__ == "__main__":

--- a/tests/whisper/test_implementations.py
+++ b/tests/whisper/test_implementations.py
@@ -90,6 +90,104 @@ class TestWhisperImplementations(unittest.TestCase):
         finally:
             os.unlink(audio_path)
 
+    def test_openai_gpt_transcribe_normalizes_text_only_response(self):
+        from app.whisper.openai import OpenAIApi
+
+        model_dump = Mock(return_value={"text": "hello from gpt"})
+        create_mock = Mock(return_value=Mock(model_dump=model_dump))
+        client = Mock()
+        client.audio.transcriptions.create = create_mock
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
+            create_tiny_wav(temp_audio.name)
+            audio_path = temp_audio.name
+
+        try:
+            with patch("app.whisper.openai.OpenAI", return_value=client):
+                implementation = OpenAIApi(
+                    api_key="test-key", model="gpt-4o-transcribe"
+                )
+                result = implementation.transcribe(
+                    audio=audio_path, options=build_options(), language="en"
+                )
+
+            kwargs = create_mock.call_args.kwargs
+            self.assertEqual("gpt-4o-transcribe", kwargs["model"])
+            self.assertEqual("json", kwargs["response_format"])
+            self.assertIn("alpha bravo", kwargs["prompt"])
+            self.assertNotIn("chunking_strategy", kwargs)
+            self.assertEqual(
+                {
+                    "text": "hello from gpt",
+                    "segments": [{"start": 0.0, "end": 0.0, "text": "hello from gpt"}],
+                    "language": "en",
+                },
+                result,
+            )
+            self._assert_result_contract(result)
+        finally:
+            os.unlink(audio_path)
+
+    def test_openai_gpt_transcription_models_use_json_response_format(self):
+        from app.whisper.openai import OpenAIApi
+
+        with patch("app.whisper.openai.OpenAI"):
+            for model in (
+                "gpt-4o-transcribe",
+                "gpt-4o-mini-transcribe",
+                "gpt-4o-mini-transcribe-2025-12-15",
+            ):
+                with self.subTest(model=model):
+                    implementation = OpenAIApi(api_key="test-key", model=model)
+                    self.assertEqual("json", implementation.response_format)
+
+    def test_openai_diarization_uses_timestamped_segments_without_prompt(self):
+        from app.whisper.openai import OpenAIApi
+
+        response = {
+            "text": "one two",
+            "segments": [
+                {
+                    "start": 0.1,
+                    "end": 0.8,
+                    "text": "one",
+                    "speaker": "A",
+                },
+                {
+                    "start": 0.9,
+                    "end": 1.5,
+                    "text": "two",
+                    "speaker": "B",
+                },
+            ],
+        }
+        create_mock = Mock(return_value=Mock(model_dump=Mock(return_value=response)))
+        client = Mock()
+        client.audio.transcriptions.create = create_mock
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
+            create_tiny_wav(temp_audio.name)
+            audio_path = temp_audio.name
+
+        try:
+            with patch("app.whisper.openai.OpenAI", return_value=client):
+                implementation = OpenAIApi(
+                    api_key="test-key", model="gpt-4o-transcribe-diarize"
+                )
+                result = implementation.transcribe(
+                    audio=audio_path, options=build_options(), language="en"
+                )
+
+            kwargs = create_mock.call_args.kwargs
+            self.assertEqual("diarized_json", kwargs["response_format"])
+            self.assertEqual("auto", kwargs["chunking_strategy"])
+            self.assertNotIn("prompt", kwargs)
+            self.assertEqual("A", result["segments"][0]["speaker"])
+            self.assertEqual(0.9, result["segments"][1]["start"])
+            self._assert_result_contract(result)
+        finally:
+            os.unlink(audio_path)
+
     def test_deepinfra_api_transcribe_structural_contract(self):
         from app.whisper.deepinfra import DeepInfraApi
 

--- a/tests/whisper/test_providers_live.py
+++ b/tests/whisper/test_providers_live.py
@@ -37,7 +37,10 @@ class TestLiveProviders(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY not set")
     def test_openai_live(self):
-        implementation = OpenAIApi(api_key=os.environ["OPENAI_API_KEY"])
+        implementation = OpenAIApi(
+            api_key=os.environ["OPENAI_API_KEY"],
+            model=os.getenv("OPENAI_TRANSCRIPTION_MODEL", "whisper-1"),
+        )
         result = implementation.transcribe(TINY_AUDIO_FILE, build_options(), "en")
         self._assert_result_contract(result)
 

--- a/tests/whisper/test_task_model_selection.py
+++ b/tests/whisper/test_task_model_selection.py
@@ -25,6 +25,19 @@ class TestWhisperTaskModelSelection(unittest.TestCase):
         ):
             self.assertEqual("openai:whisper-1", self.task.default_implementation)
 
+    def test_default_implementation_openai_uses_configured_transcription_model(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WHISPER_IMPLEMENTATION": "openai",
+                "OPENAI_TRANSCRIPTION_MODEL": "gpt-4o-mini-transcribe",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                "openai:gpt-4o-mini-transcribe", self.task.default_implementation
+            )
+
     def test_default_implementation_deepgram_uses_default_model(self):
         with patch.dict(os.environ, {"WHISPER_IMPLEMENTATION": "deepgram"}, clear=True):
             self.assertEqual("deepgram:nova-2", self.task.default_implementation)
@@ -76,6 +89,15 @@ class TestWhisperTaskModelSelection(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaisesRegex(RuntimeError, "OPENAI_API_KEY env must be set"):
                 self.task.initialize_model("openai:whisper-1")
+
+    def test_initialize_model_openai_passes_selected_model(self):
+        with (
+            patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True),
+            patch("app.whisper.openai.OpenAIApi") as openai_api,
+        ):
+            self.task.initialize_model("openai:gpt-4o-transcribe")
+
+        openai_api.assert_called_once_with("test-key", "gpt-4o-transcribe")
 
     def test_initialize_model_deepgram_requires_api_key(self):
         with patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## What changed

- allow the OpenAI transcription model to be selected with `OPENAI_TRANSCRIPTION_MODEL`
- choose the response format required by each current OpenAI transcription model
- normalize text-only GPT transcription responses into trunk-transcribe's segment contract
- preserve timestamped speaker segments from `gpt-4o-transcribe-diarize`
- store diarized segments as `Speaker A:`, `Speaker B:`, and so on throughout raw transcripts, search results, notifications, and returned task text
- avoid sending unsupported prompts to the diarization model and enable automatic chunking
- document the OpenAI worker configuration and add model-specific tests

## Why

The OpenAI adapter hard-coded `whisper-1` and `response_format="verbose_json"`. Current GPT transcription models do not all support that format: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` return text-only JSON, while the diarization model uses `diarized_json`. The radio processing layer also discarded the diarization model's speaker field when building the stored transcript.

## Impact

Existing `whisper-1` behavior remains the default. Users can select `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, or `gpt-4o-transcribe-diarize`. Text-only models are represented as one untimed compatibility segment. Diarized transcripts retain timestamps and store visible speaker labels without changing non-diarized output.

## Validation

- `36 passed, 7 skipped` across `tests/whisper` and `tests/radio`
- Ruff checks and formatting pass
- mypy passes for the changed application modules
- `git diff --check` passes

Live provider tests and service-dependent integration tests were not run because they require API credentials and supporting services.